### PR TITLE
Refactor multi-device low-level resource and heap allocation

### DIFF
--- a/lci/api/lci.h
+++ b/lci/api/lci.h
@@ -594,13 +594,6 @@ extern LCI_rdv_protocol_t LCI_RDV_PROTOCOL;
 
 /**
  * @ingroup LCI_COMM
- * @brief For the libfabric cxi provider, Try turning off the hacking to see
- * whether cxi has fixed the double mr_bind error.
- */
-extern bool LCI_OFI_CXI_TRY_NO_HACK;
-
-/**
- * @ingroup LCI_COMM
  * @brief For the UCX backend, use try_lock to wrap the ucx function calls.
  */
 extern bool LCI_UCX_USE_TRY_LOCK;

--- a/lci/api/lci.h
+++ b/lci/api/lci.h
@@ -692,6 +692,8 @@ LCI_error_t LCI_barrier();
  */
 LCI_API
 LCI_error_t LCI_device_init(LCI_device_t* device_ptr);
+LCI_API
+LCI_error_t LCI_device_initx(LCI_device_t* device_ptr);
 /**
  * @ingroup LCI_DEVICE
  * @brief Initialize a device.

--- a/lci/backend/ibv/server_ibv.c
+++ b/lci/backend/ibv/server_ibv.c
@@ -73,11 +73,10 @@ void LCISI_event_polling_thread_fina(LCISI_server_t* server)
   }
 }
 
-void LCISD_server_init(LCI_device_t device, LCIS_server_t* s)
+void LCISD_server_init(LCIS_server_t* s)
 {
   LCISI_server_t* server = LCIU_malloc(sizeof(LCISI_server_t));
   *s = (LCIS_server_t)server;
-  server->device = device;
 
   int num_devices;
   server->dev_list = ibv_get_device_list(&num_devices);

--- a/lci/backend/ibv/server_ibv.h
+++ b/lci/backend/ibv/server_ibv.h
@@ -140,7 +140,8 @@ static inline int LCISD_poll_cq(LCIS_endpoint_t endpoint_pp,
 #ifdef LCI_ENABLE_MULTITHREAD_PROGRESS
   LCIU_release_spinlock(&endpoint_p->cq_lock);
 #endif
-  if (ne > 0) LCII_PCOUNTER_ADD(net_poll_cq_num, ne);
+  LCII_PCOUNTER_ADD(net_poll_cq_calls, 1);
+  if (ne > 0) LCII_PCOUNTER_ADD(net_poll_cq_entry_count, ne);
   for (int i = 0; i < ne; i++) {
     LCI_DBG_Assert(
         wc[i].status == IBV_WC_SUCCESS, "Failed status %s (%d) for wr_id %d\n",

--- a/lci/backend/ofi/server_ofi.c
+++ b/lci/backend/ofi/server_ofi.c
@@ -103,6 +103,10 @@ void LCISD_server_init(LCIS_server_t* s)
     LCI_Assert(LCI_USE_DREG == 0,
                "The registration cache should be turned off "
                "for libfabric cxi backend. Use `export LCI_USE_DREG=0`.\n");
+    LCI_Assert(LCI_ENABLE_PRG_NET_ENDPOINT == 0,
+               "The progress-specific network endpoint "
+               "for libfabric cxi backend. Use `export "
+               "LCI_ENABLE_PRG_NET_ENDPOINT=0`.\n");
     if (LCI_RDV_PROTOCOL != LCI_RDV_WRITE) {
       LCI_RDV_PROTOCOL = LCI_RDV_WRITE;
       LCI_Warn(
@@ -116,15 +120,11 @@ void LCISD_server_init(LCIS_server_t* s)
 
   // Create domain.
   FI_SAFECALL(fi_domain(server->fabric, server->info, &server->domain, NULL));
-
-  server->endpoint_count = 0;
 }
 
 void LCISD_server_fina(LCIS_server_t s)
 {
   LCISI_server_t* server = (LCISI_server_t*)s;
-  LCI_Assert(server->endpoint_count == 0, "Endpoint count is not zero (%d)\n",
-             server->endpoint_count);
   FI_SAFECALL(fi_close((struct fid*)&server->domain->fid));
   FI_SAFECALL(fi_close((struct fid*)&server->fabric->fid));
   fi_freeinfo(server->info);
@@ -138,19 +138,7 @@ void LCISD_endpoint_init(LCIS_server_t server_pp, LCIS_endpoint_t* endpoint_pp,
   LCISI_endpoint_t* endpoint_p = LCIU_malloc(sizeof(LCISI_endpoint_t));
   *endpoint_pp = (LCIS_endpoint_t)endpoint_p;
   endpoint_p->server = (LCISI_server_t*)server_pp;
-  endpoint_p->server->endpoints[endpoint_p->server->endpoint_count++] =
-      endpoint_p;
   endpoint_p->is_single_threaded = single_threaded;
-  if (!LCI_OFI_CXI_TRY_NO_HACK &&
-      strcmp(endpoint_p->server->info->fabric_attr->prov_name, "cxi") == 0 &&
-      endpoint_p->server->info->domain_attr->mr_mode & FI_MR_ENDPOINT &&
-      endpoint_p->server->endpoint_count > 1) {
-    // We are using more than one endpoint per server, but the cxi provider
-    // can only bind mr to one endpoint. We have to guess here.
-    endpoint_p->server->cxi_mr_bind_hack = true;
-  } else {
-    endpoint_p->server->cxi_mr_bind_hack = false;
-  }
   // Create end-point;
   endpoint_p->server->info->tx_attr->size = LCI_SERVER_MAX_SENDS;
   endpoint_p->server->info->rx_attr->size = LCI_SERVER_MAX_RECVS;
@@ -223,10 +211,6 @@ void LCISD_endpoint_fina(LCIS_endpoint_t endpoint_pp)
   LCT_pmi_barrier();
   LCISI_endpoint_t* endpoint_p = (LCISI_endpoint_t*)endpoint_pp;
   LCIU_free(endpoint_p->peer_addrs);
-  int my_idx = --endpoint_p->server->endpoint_count;
-  LCI_Assert(endpoint_p->server->endpoints[my_idx] == endpoint_p,
-             "This is not me!\n");
-  endpoint_p->server->endpoints[my_idx] = NULL;
   FI_SAFECALL(fi_close((struct fid*)&endpoint_p->ep->fid));
   FI_SAFECALL(fi_close((struct fid*)&endpoint_p->cq->fid));
   FI_SAFECALL(fi_close((struct fid*)&endpoint_p->av->fid));

--- a/lci/backend/ofi/server_ofi.c
+++ b/lci/backend/ofi/server_ofi.c
@@ -15,11 +15,10 @@ static struct fi_info* search_for_prov(struct fi_info* info, char* prov_name)
   return NULL;
 }
 
-void LCISD_server_init(LCI_device_t device, LCIS_server_t* s)
+void LCISD_server_init(LCIS_server_t* s)
 {
   LCISI_server_t* server = LCIU_malloc(sizeof(LCISI_server_t));
   *s = (LCIS_server_t)server;
-  server->device = device;
 
   // Create hint.
   char* p = getenv("LCI_OFI_PROVIDER_HINT");

--- a/lci/backend/ofi/server_ofi.h
+++ b/lci/backend/ofi/server_ofi.h
@@ -120,8 +120,9 @@ static inline int LCISD_poll_cq(LCIS_endpoint_t endpoint_pp,
   ne = fi_cq_read(endpoint_p->cq, &fi_entry, LCI_CQ_MAX_POLL);
   LCISI_OFI_CS_EXIT(endpoint_p, LCI_BACKEND_TRY_LOCK_POLL)
   ret = ne;
+  LCII_PCOUNTER_ADD(net_poll_cq_calls, 1);
   if (ne > 0) {
-    LCII_PCOUNTER_ADD(net_poll_cq_num, ne);
+    LCII_PCOUNTER_ADD(net_poll_cq_entry_count, ne);
     // Got an entry here
     for (int i = 0; i < ne; i++) {
       if (fi_entry[i].flags & FI_RECV) {

--- a/lci/backend/ofi/server_ofi.h
+++ b/lci/backend/ofi/server_ofi.h
@@ -38,12 +38,12 @@ struct LCISI_endpoint_t;
 typedef struct __attribute__((aligned(LCI_CACHE_LINE))) LCISI_server_t {
   struct fi_info* info;
   struct fid_fabric* fabric;
-  struct fid_domain* domain;
 } LCISI_server_t;
 
 typedef struct __attribute__((aligned(LCI_CACHE_LINE))) LCISI_endpoint_t {
   struct LCISI_endpoint_super_t super;
   LCISI_server_t* server;
+  struct fid_domain* domain;
   struct fid_ep* ep;
   struct fid_cq* cq;
   struct fid_av* av;
@@ -65,7 +65,7 @@ static inline void* LCISI_real_server_reg(LCIS_endpoint_t endpoint_pp,
     rdma_key = __sync_fetch_and_add(&g_next_rdma_key, 1);
   }
   struct fid_mr* mr;
-  FI_SAFECALL(fi_mr_reg(server->domain, buf, size,
+  FI_SAFECALL(fi_mr_reg(endpoint_p->domain, buf, size,
                         FI_READ | FI_WRITE | FI_REMOTE_WRITE, 0, rdma_key, 0,
                         &mr, 0));
   if (server->info->domain_attr->mr_mode & FI_MR_ENDPOINT) {

--- a/lci/backend/server.h
+++ b/lci/backend/server.h
@@ -165,6 +165,7 @@ static inline void LCIS_endpoint_fina(LCIS_endpoint_t endpoint_pp)
 static inline int LCIS_poll_cq(LCIS_endpoint_t endpoint_pp,
                                LCIS_cq_entry_t* entry)
 {
+  LCII_PCOUNTER_ADD(net_poll_cq_attempts, 1);
   LCISI_CS_ENTER(endpoint_pp, 0);
   int ret = LCISD_poll_cq(endpoint_pp, entry);
   LCISI_CS_EXIT(endpoint_pp);

--- a/lci/backend/server.h
+++ b/lci/backend/server.h
@@ -49,9 +49,10 @@ static inline void LCIS_serve_send(void* ctx);
 
 /* Following functions are required to be implemented by each server backend. */
 
-void LCISD_server_init(LCI_device_t device, LCIS_server_t* s);
+void LCISD_server_init(LCIS_server_t* s);
 void LCISD_server_fina(LCIS_server_t s);
-static inline LCIS_mr_t LCISD_rma_reg(LCIS_server_t s, void* buf, size_t size);
+static inline LCIS_mr_t LCISD_rma_reg(LCIS_endpoint_t endpoint_pp, void* buf,
+                                      size_t size);
 static inline void LCISD_rma_dereg(LCIS_mr_t mr);
 static inline LCIS_rkey_t LCISD_rma_rkey(LCIS_mr_t mr);
 
@@ -116,10 +117,7 @@ static inline LCI_error_t LCISD_post_recv(LCIS_endpoint_t endpoint_pp,
     LCIU_release_spinlock(&LCIS_endpoint_super(endpoint).lock);
 
 /* Wrapper functions */
-static inline void LCIS_server_init(LCI_device_t device, LCIS_server_t* s)
-{
-  LCISD_server_init(device, s);
-}
+static inline void LCIS_server_init(LCIS_server_t* s) { LCISD_server_init(s); }
 
 static inline void LCIS_server_fina(LCIS_server_t s) { LCISD_server_fina(s); }
 
@@ -128,10 +126,11 @@ static inline LCIS_rkey_t LCIS_rma_rkey(LCIS_mr_t mr)
   return LCISD_rma_rkey(mr);
 }
 
-static inline LCIS_mr_t LCIS_rma_reg(LCIS_server_t s, void* buf, size_t size)
+static inline LCIS_mr_t LCIS_rma_reg(LCIS_endpoint_t endpoint_pp, void* buf,
+                                     size_t size)
 {
   LCII_PCOUNTER_START(net_mem_reg_timer);
-  LCIS_mr_t mr = LCISD_rma_reg(s, buf, size);
+  LCIS_mr_t mr = LCISD_rma_reg(endpoint_pp, buf, size);
   LCII_PCOUNTER_END(net_mem_reg_timer);
   LCI_DBG_Log(LCI_LOG_TRACE, "server-reg",
               "LCIS_rma_reg: mr %p buf %p size %lu rkey %lu\n", mr.mr_p, buf,

--- a/lci/profile/performance_counter.h
+++ b/lci/profile/performance_counter.h
@@ -30,7 +30,9 @@ extern LCT_pcounter_ctx_t LCII_pcounter_ctx;
     _macro(net_send_failed_lock)             \
     _macro(net_send_failed_nomem)            \
     _macro(net_recv_failed_nopacket)         \
-    _macro(net_poll_cq_num)                  \
+    _macro(net_poll_cq_attempts)             \
+    _macro(net_poll_cq_calls)                \
+    _macro(net_poll_cq_entry_count)          \
     _macro(progress_call)                    \
     _macro(packet_get)                       \
     _macro(packet_put)                       \

--- a/lci/runtime/1sided_primitive.c
+++ b/lci/runtime/1sided_primitive.c
@@ -49,7 +49,8 @@ LCI_error_t LCI_putmac(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                  "(set by LCI_plist_set_default_comp, "
                  "the default value is LCI_UR_CQ)\n");
   LCI_error_t ret = LCI_OK;
-  bool is_user_provided_packet = LCII_is_packet(buffer.address);
+  bool is_user_provided_packet =
+      LCII_is_packet(ep->device->heap, buffer.address);
   if (local_completion == NULL && buffer.length <= LCI_SHORT_SIZE) {
     /* if data is this short, we will be able to inline it
      * no reason to get a packet, allocate a ctx, etc */

--- a/lci/runtime/1sided_primitive.c
+++ b/lci/runtime/1sided_primitive.c
@@ -49,7 +49,7 @@ LCI_error_t LCI_putmac(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                  "(set by LCI_plist_set_default_comp, "
                  "the default value is LCI_UR_CQ)\n");
   LCI_error_t ret = LCI_OK;
-  bool is_user_provided_packet = LCII_is_packet(ep->device, buffer.address);
+  bool is_user_provided_packet = LCII_is_packet(buffer.address);
   if (local_completion == NULL && buffer.length <= LCI_SHORT_SIZE) {
     /* if data is this short, we will be able to inline it
      * no reason to get a packet, allocate a ctx, etc */
@@ -94,7 +94,7 @@ LCI_error_t LCI_putmac(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
     }
     ret = LCIS_post_send(
         ep->device->endpoint_worker->endpoint, rank, packet->data.address,
-        buffer.length, ep->device->heap.segment->mr,
+        buffer.length, ep->device->heap_segment->mr,
         LCII_MAKE_PROTO(ep->gid, LCI_MSG_RDMA_MEDIUM, tag), ctx);
     if (ret == LCI_ERR_RETRY) {
       if (!is_user_provided_packet) LCII_free_packet(packet);
@@ -179,7 +179,7 @@ LCI_error_t LCI_putla(LCI_endpoint_t ep, LCI_lbuffer_t buffer,
               packet->data.rts.size);
   LCI_error_t ret = LCIS_post_send(
       ep->device->endpoint_worker->endpoint, rank, packet->data.address,
-      sizeof(struct LCII_packet_rts_t), ep->device->heap.segment->mr,
+      sizeof(struct LCII_packet_rts_t), ep->device->heap_segment->mr,
       LCII_MAKE_PROTO(ep->gid, LCI_MSG_RTS, tag), rts_ctx);
   if (ret == LCI_ERR_RETRY) {
     LCII_free_packet(packet);
@@ -278,7 +278,7 @@ LCI_error_t LCI_putva(LCI_endpoint_t ep, LCI_iovec_t iovec,
                   (uintptr_t)packet->data.address + iovec.piggy_back.length;
   LCI_error_t ret =
       LCIS_post_send(ep->device->endpoint_worker->endpoint, rank,
-                     packet->data.address, length, ep->device->heap.segment->mr,
+                     packet->data.address, length, ep->device->heap_segment->mr,
                      LCII_MAKE_PROTO(ep->gid, LCI_MSG_RTS, tag), rts_ctx);
   if (ret == LCI_ERR_RETRY) {
     LCII_free_packet(packet);

--- a/lci/runtime/2sided_primitive.c
+++ b/lci/runtime/2sided_primitive.c
@@ -26,7 +26,8 @@ LCI_error_t LCI_sendmc(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                  "buffer is too large %lu (maximum: %d)\n", buffer.length,
                  LCI_MEDIUM_SIZE);
   LCI_error_t ret = LCI_OK;
-  bool is_user_provided_packet = LCII_is_packet(buffer.address);
+  bool is_user_provided_packet =
+      LCII_is_packet(ep->device->heap, buffer.address);
   if (completion == NULL && buffer.length <= LCI_SHORT_SIZE) {
     /* if data is this short, we will be able to inline it
      * no reason to get a packet, allocate a ctx, etc */

--- a/lci/runtime/2sided_primitive.c
+++ b/lci/runtime/2sided_primitive.c
@@ -26,7 +26,7 @@ LCI_error_t LCI_sendmc(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
                  "buffer is too large %lu (maximum: %d)\n", buffer.length,
                  LCI_MEDIUM_SIZE);
   LCI_error_t ret = LCI_OK;
-  bool is_user_provided_packet = LCII_is_packet(ep->device, buffer.address);
+  bool is_user_provided_packet = LCII_is_packet(buffer.address);
   if (completion == NULL && buffer.length <= LCI_SHORT_SIZE) {
     /* if data is this short, we will be able to inline it
      * no reason to get a packet, allocate a ctx, etc */
@@ -72,7 +72,7 @@ LCI_error_t LCI_sendmc(LCI_endpoint_t ep, LCI_mbuffer_t buffer, int rank,
 
     ret = LCIS_post_send(ep->device->endpoint_worker->endpoint, rank,
                          packet->data.address, buffer.length,
-                         ep->device->heap.segment->mr,
+                         ep->device->heap_segment->mr,
                          LCII_MAKE_PROTO(ep->gid, LCI_MSG_MEDIUM, tag), ctx);
     if (ret == LCI_ERR_RETRY) {
       if (!is_user_provided_packet) LCII_free_packet(packet);
@@ -141,7 +141,7 @@ LCI_error_t LCI_sendl(LCI_endpoint_t ep, LCI_lbuffer_t buffer, int rank,
 
   LCI_error_t ret = LCIS_post_send(
       ep->device->endpoint_worker->endpoint, rank, packet->data.address,
-      sizeof(struct LCII_packet_rts_t), ep->device->heap.segment->mr,
+      sizeof(struct LCII_packet_rts_t), ep->device->heap_segment->mr,
       LCII_MAKE_PROTO(ep->gid, LCI_MSG_RTS, tag), rts_ctx);
   if (ret == LCI_ERR_RETRY) {
     LCII_free_packet(packet);

--- a/lci/runtime/device.c
+++ b/lci/runtime/device.c
@@ -60,7 +60,9 @@ LCI_error_t LCI_device_init(LCI_device_t* device_ptr)
   LCII_bq_init(&device->bq);
   LCIU_spinlock_init(&device->bq_spinlock);
 
-  LCI_memory_register(device, g_heap, g_heap_size, &device->heap_segment);
+  device->heap = &g_heap;
+  LCI_memory_register(device, device->heap->address, device->heap->length,
+                      &device->heap_segment);
 
   if (LCI_ENABLE_PRG_NET_ENDPOINT)
     LCII_fill_rq(device->endpoint_progress, true);
@@ -80,10 +82,10 @@ LCI_error_t LCI_device_free(LCI_device_t* device_ptr)
   LCI_device_t device = *device_ptr;
   LCI_Log(LCI_LOG_INFO, "device", "free device %p\n", device);
   LCI_barrier();
-  g_total_recv_posted +=
+  device->heap->total_recv_posted +=
       LCII_endpoint_get_recv_posted(device->endpoint_worker);
   if (LCI_ENABLE_PRG_NET_ENDPOINT) {
-    g_total_recv_posted +=
+    device->heap->total_recv_posted +=
         LCII_endpoint_get_recv_posted(device->endpoint_progress);
   }
   LCII_matchtable_free(&device->mt);

--- a/lci/runtime/device.c
+++ b/lci/runtime/device.c
@@ -15,7 +15,7 @@ void LCII_device_endpoint_init(LCI_device_t device, bool single_threaded,
   endpoint_p->recv_posted = 0;
 #endif
   endpoint_p->device = device;
-  LCIS_endpoint_init(device->server, &endpoint_p->endpoint, single_threaded);
+  LCIS_endpoint_init(g_server, &endpoint_p->endpoint, single_threaded);
 }
 
 void LCII_endpoint_fina(LCII_endpoint_t** endpoint_pp)
@@ -44,7 +44,6 @@ LCI_error_t LCI_device_init(LCI_device_t* device_ptr)
 #ifdef LCI_ENABLE_MULTITHREAD_PROGRESS
   single_threaded_prg = false;
 #endif
-  LCIS_server_init(device, &device->server);
   LCII_device_endpoint_init(device, false, &device->endpoint_worker);
   if (LCI_ENABLE_PRG_NET_ENDPOINT) {
     LCII_device_endpoint_init(device, single_threaded_prg,
@@ -128,7 +127,6 @@ LCI_error_t LCI_device_free(LCI_device_t* device_ptr)
     LCII_endpoint_fina(&device->endpoint_progress);
   }
   LCII_endpoint_fina(&device->endpoint_worker);
-  LCIS_server_fina(device->server);
   LCIU_free(device);
   *device_ptr = NULL;
   return LCI_OK;

--- a/lci/runtime/device.c
+++ b/lci/runtime/device.c
@@ -60,37 +60,8 @@ LCI_error_t LCI_device_init(LCI_device_t* device_ptr)
   LCII_bq_init(&device->bq);
   LCIU_spinlock_init(&device->bq_spinlock);
 
-  const size_t heap_size =
-      LCI_CACHE_LINE + (size_t)LCI_SERVER_NUM_PKTS * LCI_PACKET_SIZE;
-  LCI_error_t ret =
-      LCI_lbuffer_memalign(device, heap_size, LCI_PAGESIZE, &device->heap);
-  LCI_Assert(ret == LCI_OK, "Device heap memory allocation failed\n");
-  uintptr_t base_addr = (uintptr_t)device->heap.address;
+  LCI_memory_register(device, g_heap, g_heap_size, &device->heap_segment);
 
-  LCI_Assert(sizeof(struct LCII_packet_context) <= LCI_CACHE_LINE,
-             "Unexpected packet_context size\n");
-  device->base_packet =
-      base_addr + LCI_CACHE_LINE - sizeof(struct LCII_packet_context);
-  LCI_Assert(LCI_PACKET_SIZE % LCI_CACHE_LINE == 0,
-             "The size of packets should be a multiple of cache line size\n");
-
-  LCII_pool_create(&device->pkpool);
-  for (size_t i = 0; i < LCI_SERVER_NUM_PKTS; i++) {
-    LCII_packet_t* packet =
-        (LCII_packet_t*)(device->base_packet + i * LCI_PACKET_SIZE);
-    LCI_Assert(((uint64_t) & (packet->data)) % LCI_CACHE_LINE == 0,
-               "packet.data is not well-aligned\n");
-    LCI_Assert(LCII_is_packet(device, packet->data.address),
-               "Not a packet. The computation is wrong!\n");
-    packet->context.pkpool = device->pkpool;
-    packet->context.poolid = 0;
-#ifdef LCI_DEBUG
-    packet->context.isInPool = true;
-#endif
-    LCII_pool_put(device->pkpool, packet);
-  }
-  LCI_Assert(LCI_SERVER_NUM_PKTS > 2 * LCI_SERVER_MAX_RECVS,
-             "The packet number is too small!\n");
   if (LCI_ENABLE_PRG_NET_ENDPOINT)
     LCII_fill_rq(device->endpoint_progress, true);
   LCII_fill_rq(device->endpoint_worker, true);
@@ -99,27 +70,26 @@ LCI_error_t LCI_device_init(LCI_device_t* device_ptr)
   return LCI_OK;
 }
 
+LCI_error_t LCI_device_initx(LCI_device_t* device_ptr)
+{
+  return LCI_device_init(device_ptr);
+}
+
 LCI_error_t LCI_device_free(LCI_device_t* device_ptr)
 {
   LCI_device_t device = *device_ptr;
   LCI_Log(LCI_LOG_INFO, "device", "free device %p\n", device);
   LCI_barrier();
-  int total_recv_posted =
+  g_total_recv_posted +=
       LCII_endpoint_get_recv_posted(device->endpoint_worker);
   if (LCI_ENABLE_PRG_NET_ENDPOINT) {
-    total_recv_posted +=
+    g_total_recv_posted +=
         LCII_endpoint_get_recv_posted(device->endpoint_progress);
   }
-  int total_num = LCII_pool_count(device->pkpool) + total_recv_posted;
-  if (total_num != LCI_SERVER_NUM_PKTS)
-    LCI_Warn("Potentially losing packets %d != %d\n", total_num,
-             LCI_SERVER_NUM_PKTS);
   LCII_matchtable_free(&device->mt);
   LCM_archive_fini(&(device->ctx_archive));
   LCII_bq_fini(&device->bq);
   LCIU_spinlock_fina(&device->bq_spinlock);
-  LCI_lbuffer_free(device->heap);
-  LCII_pool_destroy(device->pkpool);
   if (LCI_USE_DREG) {
     LCII_rcache_fina(device);
   }

--- a/lci/runtime/device.c
+++ b/lci/runtime/device.c
@@ -88,6 +88,7 @@ LCI_error_t LCI_device_free(LCI_device_t* device_ptr)
     device->heap->total_recv_posted +=
         LCII_endpoint_get_recv_posted(device->endpoint_progress);
   }
+  LCI_memory_deregister(&device->heap_segment);
   LCII_matchtable_free(&device->mt);
   LCM_archive_fini(&(device->ctx_archive));
   LCII_bq_fini(&device->bq);

--- a/lci/runtime/endpoint.c
+++ b/lci/runtime/endpoint.c
@@ -14,7 +14,7 @@ LCI_error_t LCII_endpoint_init(LCI_endpoint_t* ep_ptr, LCI_device_t device,
   *ep_ptr = ep;
 
   ep->device = device;
-  ep->pkpool = device->pkpool;
+  ep->pkpool = g_pkpool;
   ep->mt = device->mt;
   ep->ctx_archive_p = &device->ctx_archive;
   ep->bq_p = &device->bq;

--- a/lci/runtime/endpoint.c
+++ b/lci/runtime/endpoint.c
@@ -14,7 +14,7 @@ LCI_error_t LCII_endpoint_init(LCI_endpoint_t* ep_ptr, LCI_device_t device,
   *ep_ptr = ep;
 
   ep->device = device;
-  ep->pkpool = g_pkpool;
+  ep->pkpool = device->heap->pool;
   ep->mt = device->mt;
   ep->ctx_archive_p = &device->ctx_archive;
   ep->bq_p = &device->bq;

--- a/lci/runtime/lci.c
+++ b/lci/runtime/lci.c
@@ -7,6 +7,7 @@ static int opened = 0;
 int LCIU_nthreads = 0;
 __thread int LCIU_thread_id = -1;
 __thread unsigned int LCIU_rand_seed = 0;
+LCIS_server_t g_server;
 
 LCI_error_t LCI_initialize()
 {
@@ -36,6 +37,7 @@ LCI_error_t LCI_initialize()
 #endif
   }
 
+  LCIS_server_init(&g_server);
   LCI_device_init(&LCI_UR_DEVICE);
 
   LCI_queue_create(LCI_UR_DEVICE, &LCI_UR_CQ);
@@ -66,6 +68,7 @@ LCI_error_t LCI_finalize()
   LCI_endpoint_free(&LCI_UR_ENDPOINT);
   LCI_queue_free(&LCI_UR_CQ);
   LCI_device_free(&LCI_UR_DEVICE);
+  LCIS_server_fina(g_server);
   if (LCI_USE_DREG) {
 #ifdef LCI_COMPILE_DREG
     LCII_ucs_cleanup();

--- a/lci/runtime/lci.c
+++ b/lci/runtime/lci.c
@@ -8,6 +8,11 @@ int LCIU_nthreads = 0;
 __thread int LCIU_thread_id = -1;
 __thread unsigned int LCIU_rand_seed = 0;
 LCIS_server_t g_server;
+void *g_heap;
+size_t g_heap_size;
+void *g_base_packet;
+LCII_pool_t* g_pkpool;
+int g_total_recv_posted;
 
 LCI_error_t LCI_initialize()
 {
@@ -36,10 +41,38 @@ LCI_error_t LCI_initialize()
     LCI_Assert(false, "LCI_COMPILE_DREG is not enabled!\n");
 #endif
   }
-
+  // initialize global data structure
   LCIS_server_init(&g_server);
-  LCI_device_init(&LCI_UR_DEVICE);
+  g_heap_size =
+      LCI_CACHE_LINE + (size_t)LCI_SERVER_NUM_PKTS * LCI_PACKET_SIZE;
+  g_heap = LCIU_memalign(LCI_PAGESIZE, g_heap_size);
+  LCI_Assert(LCI_CACHE_LINE >= sizeof(struct LCII_packet_context),
+             "packet context is too large!\n");
+  g_base_packet =
+      g_heap + LCI_CACHE_LINE - sizeof(struct LCII_packet_context);
+  LCI_Assert(LCI_PACKET_SIZE % LCI_CACHE_LINE == 0,
+             "The size of packets should be a multiple of cache line size\n");
 
+  LCII_pool_create(&g_pkpool);
+  for (size_t i = 0; i < LCI_SERVER_NUM_PKTS; i++) {
+    LCII_packet_t* packet =
+        (LCII_packet_t*)(g_base_packet + i * LCI_PACKET_SIZE);
+    LCI_Assert(((uint64_t) & (packet->data)) % LCI_CACHE_LINE == 0,
+               "packet.data is not well-aligned\n");
+    LCI_Assert(LCII_is_packet(packet->data.address),
+               "Not a packet. The computation is wrong!\n");
+    packet->context.pkpool = g_pkpool;
+    packet->context.poolid = 0;
+#ifdef LCI_DEBUG
+    packet->context.isInPool = true;
+#endif
+    LCII_pool_put(g_pkpool, packet);
+  }
+  LCI_Assert(LCI_SERVER_NUM_PKTS > 2 * LCI_SERVER_MAX_RECVS,
+             "The packet number is too small!\n");
+  g_total_recv_posted = 0;
+  // UR objects
+  LCI_device_init(&LCI_UR_DEVICE);
   LCI_queue_create(LCI_UR_DEVICE, &LCI_UR_CQ);
   LCI_plist_t plist;
   LCI_plist_create(&plist);
@@ -68,6 +101,12 @@ LCI_error_t LCI_finalize()
   LCI_endpoint_free(&LCI_UR_ENDPOINT);
   LCI_queue_free(&LCI_UR_CQ);
   LCI_device_free(&LCI_UR_DEVICE);
+  int total_num = LCII_pool_count(g_pkpool) + g_total_recv_posted;
+  if (total_num != LCI_SERVER_NUM_PKTS)
+    LCI_Warn("Potentially losing packets %d != %d\n", total_num,
+             LCI_SERVER_NUM_PKTS);
+  LCII_pool_destroy(g_pkpool);
+  LCIU_free(g_heap);
   LCIS_server_fina(g_server);
   if (LCI_USE_DREG) {
 #ifdef LCI_COMPILE_DREG

--- a/lci/runtime/lcii.h
+++ b/lci/runtime/lcii.h
@@ -58,22 +58,29 @@ struct LCII_endpoint_t {
 };
 typedef struct LCII_endpoint_t LCII_endpoint_t;
 
+struct LCII_packet_heap_t {
+  void* address;
+  size_t length;
+  void* base_packet_p;
+  LCII_pool_t* pool;
+  int total_recv_posted;  // for debugging purpose
+};
+typedef struct LCII_packet_heap_t LCII_packet_heap_t;
+
 extern LCIS_server_t g_server;
-extern void *g_heap;
-extern size_t g_heap_size;
-extern void *g_base_packet;
-extern LCII_pool_t* g_pkpool;
-extern int g_total_recv_posted;
+extern LCII_packet_heap_t g_heap;
 
 struct __attribute__((aligned(LCI_CACHE_LINE))) LCI_device_s {
   // the following will not be changed after initialization
   LCII_endpoint_t* endpoint_worker;    // 8B
   LCII_endpoint_t* endpoint_progress;  // 8B
   LCI_matchtable_t mt;                 // 8B
+  LCII_packet_heap_t* heap;            // 8B
   LCII_rcache_t rcache;                // 8B
   LCI_segment_t heap_segment;          // 8B
   LCIU_CACHE_PADDING(2 * sizeof(LCIS_endpoint_t) + sizeof(LCI_matchtable_t) +
-                     sizeof(LCII_rcache_t) + sizeof(LCI_segment_t));
+                     sizeof(LCII_packet_heap_t*) + sizeof(LCII_rcache_t) +
+                     sizeof(LCI_segment_t));
   // the following is shared by both progress threads and worker threads
   LCM_archive_t ctx_archive;  // used for long message protocol
   LCIU_CACHE_PADDING(sizeof(LCM_archive_t));

--- a/lci/runtime/lcii.h
+++ b/lci/runtime/lcii.h
@@ -59,20 +59,21 @@ struct LCII_endpoint_t {
 typedef struct LCII_endpoint_t LCII_endpoint_t;
 
 extern LCIS_server_t g_server;
+extern void *g_heap;
+extern size_t g_heap_size;
+extern void *g_base_packet;
+extern LCII_pool_t* g_pkpool;
+extern int g_total_recv_posted;
 
 struct __attribute__((aligned(LCI_CACHE_LINE))) LCI_device_s {
   // the following will not be changed after initialization
   LCII_endpoint_t* endpoint_worker;    // 8B
   LCII_endpoint_t* endpoint_progress;  // 8B
-  LCII_pool_t* pkpool;                 // 8B
   LCI_matchtable_t mt;                 // 8B
   LCII_rcache_t rcache;                // 8B
-  LCI_lbuffer_t heap;                  // 24B
-  uintptr_t base_packet;               // 8B
-  LCIU_CACHE_PADDING(sizeof(LCIS_server_t) + 2 * sizeof(LCIS_endpoint_t) +
-                     sizeof(LCII_pool_t*) + sizeof(LCI_matchtable_t) +
-                     sizeof(LCII_rcache_t*) + sizeof(LCI_lbuffer_t) +
-                     sizeof(uintptr_t));
+  LCI_segment_t heap_segment;          // 8B
+  LCIU_CACHE_PADDING(2 * sizeof(LCIS_endpoint_t) + sizeof(LCI_matchtable_t) +
+                     sizeof(LCII_rcache_t) + sizeof(LCI_segment_t));
   // the following is shared by both progress threads and worker threads
   LCM_archive_t ctx_archive;  // used for long message protocol
   LCIU_CACHE_PADDING(sizeof(LCM_archive_t));

--- a/lci/runtime/lcii.h
+++ b/lci/runtime/lcii.h
@@ -58,9 +58,10 @@ struct LCII_endpoint_t {
 };
 typedef struct LCII_endpoint_t LCII_endpoint_t;
 
+extern LCIS_server_t g_server;
+
 struct __attribute__((aligned(LCI_CACHE_LINE))) LCI_device_s {
   // the following will not be changed after initialization
-  LCIS_server_t server;                // 8B
   LCII_endpoint_t* endpoint_worker;    // 8B
   LCII_endpoint_t* endpoint_progress;  // 8B
   LCII_pool_t* pkpool;                 // 8B

--- a/lci/runtime/memory_registration.c
+++ b/lci/runtime/memory_registration.c
@@ -33,7 +33,7 @@ LCI_error_t LCI_memory_deregister(LCI_segment_t* segment)
 
 LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
 {
-  LCII_packet_t* packet = LCII_alloc_packet_nb(g_pkpool);
+  LCII_packet_t* packet = LCII_alloc_packet_nb(device->heap->pool);
   if (packet == NULL)
     // no packet is available
     return LCI_ERR_RETRY;
@@ -41,7 +41,7 @@ LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
 
   mbuffer->address = packet->data.address;
   mbuffer->length = LCI_MEDIUM_SIZE;
-  LCI_DBG_Assert(LCII_is_packet(mbuffer->address), "");
+  LCI_DBG_Assert(LCII_is_packet(device->heap, mbuffer->address), "");
   return LCI_OK;
 }
 

--- a/lci/runtime/memory_registration.c
+++ b/lci/runtime/memory_registration.c
@@ -33,7 +33,7 @@ LCI_error_t LCI_memory_deregister(LCI_segment_t* segment)
 
 LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
 {
-  LCII_packet_t* packet = LCII_alloc_packet_nb(device->pkpool);
+  LCII_packet_t* packet = LCII_alloc_packet_nb(g_pkpool);
   if (packet == NULL)
     // no packet is available
     return LCI_ERR_RETRY;
@@ -41,7 +41,7 @@ LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
 
   mbuffer->address = packet->data.address;
   mbuffer->length = LCI_MEDIUM_SIZE;
-  LCI_DBG_Assert(LCII_is_packet(device, mbuffer->address), "");
+  LCI_DBG_Assert(LCII_is_packet(mbuffer->address), "");
   return LCI_OK;
 }
 

--- a/lci/runtime/memory_registration.c
+++ b/lci/runtime/memory_registration.c
@@ -9,7 +9,7 @@ LCI_error_t LCI_memory_register(LCI_device_t device, void* address,
   if (LCI_USE_DREG)
     LCII_rcache_reg(device, address, length, mr);
   else {
-    mr->mr = LCIS_rma_reg(device->server, address, length);
+    mr->mr = LCIS_rma_reg(device->endpoint_progress->endpoint, address, length);
   }
   *segment = mr;
   LCII_PCOUNTER_END(mem_reg_timer);

--- a/lci/runtime/memory_registration.c
+++ b/lci/runtime/memory_registration.c
@@ -37,7 +37,6 @@ LCI_error_t LCI_mbuffer_alloc(LCI_device_t device, LCI_mbuffer_t* mbuffer)
   if (packet == NULL)
     // no packet is available
     return LCI_ERR_RETRY;
-  packet->context.poolid = LCII_POOLID_LOCAL;
 
   mbuffer->address = packet->data.address;
   mbuffer->length = LCI_MEDIUM_SIZE;

--- a/lci/runtime/packet.h
+++ b/lci/runtime/packet.h
@@ -102,12 +102,12 @@ static inline LCII_packet_t* LCII_mbuffer2packet(LCI_mbuffer_t mbuffer)
   return (LCII_packet_t*)(mbuffer.address - offsetof(LCII_packet_t, data));
 }
 
-static inline bool LCII_is_packet(LCI_device_t device, void* address)
+static inline bool LCII_is_packet(void* address)
 {
   void* packet_address =
       (LCII_packet_t*)(address - offsetof(LCII_packet_t, data));
-  uintptr_t offset = (uintptr_t)packet_address - device->base_packet;
-  return (uintptr_t)packet_address >= device->base_packet &&
+  uintptr_t offset = (uintptr_t)packet_address - (uintptr_t)g_base_packet;
+  return (uintptr_t)packet_address >= (uintptr_t)g_base_packet &&
          offset % LCI_PACKET_SIZE == 0 &&
          offset / LCI_PACKET_SIZE < LCI_SERVER_NUM_PKTS;
 }

--- a/lci/runtime/packet.h
+++ b/lci/runtime/packet.h
@@ -102,12 +102,12 @@ static inline LCII_packet_t* LCII_mbuffer2packet(LCI_mbuffer_t mbuffer)
   return (LCII_packet_t*)(mbuffer.address - offsetof(LCII_packet_t, data));
 }
 
-static inline bool LCII_is_packet(void* address)
+static inline bool LCII_is_packet(LCII_packet_heap_t* heap, void* address)
 {
   void* packet_address =
       (LCII_packet_t*)(address - offsetof(LCII_packet_t, data));
-  uintptr_t offset = (uintptr_t)packet_address - (uintptr_t)g_base_packet;
-  return (uintptr_t)packet_address >= (uintptr_t)g_base_packet &&
+  uintptr_t offset = (uintptr_t)packet_address - (uintptr_t)heap->base_packet_p;
+  return (uintptr_t)packet_address >= (uintptr_t)heap->base_packet_p &&
          offset % LCI_PACKET_SIZE == 0 &&
          offset / LCI_PACKET_SIZE < LCI_SERVER_NUM_PKTS;
 }

--- a/lci/runtime/packet.h
+++ b/lci/runtime/packet.h
@@ -70,6 +70,7 @@ static inline LCII_packet_t* LCII_alloc_packet_nb(struct LCII_pool_t* pool)
   LCII_packet_t* packet = LCII_pool_get_nb(pool);
   if (packet != NULL) {
     LCII_PCOUNTER_ADD(packet_get, 1);
+    packet->context.poolid = LCII_POOLID_LOCAL;
 #ifdef LCI_DEBUG
     LCI_DBG_Assert(packet->context.isInPool,
                    "This packet has already been allocated!\n");

--- a/lci/runtime/progress.c
+++ b/lci/runtime/progress.c
@@ -113,7 +113,7 @@ LCI_error_t LCII_fill_rq(LCII_endpoint_t* endpoint, bool block)
 
     // First, get a packet.
     LCII_PCOUNTER_START(get_recv_packet_timer);
-    LCII_packet_t* packet = LCII_alloc_packet_nb(endpoint->device->pkpool);
+    LCII_packet_t* packet = LCII_alloc_packet_nb(g_pkpool);
     LCII_PCOUNTER_END(get_recv_packet_timer);
     if (packet == NULL) {
       LCII_PCOUNTER_ADD(net_recv_failed_nopacket, 1);
@@ -124,7 +124,7 @@ LCI_error_t LCII_fill_rq(LCII_endpoint_t* endpoint, bool block)
       // packet->context.poolid = lc_pool_get_local(endpoint->device->pkpool);
       LCI_error_t rc = LCIS_post_recv(
           endpoint->endpoint, packet->data.address, LCI_MEDIUM_SIZE,
-          endpoint->device->heap.segment->mr, packet);
+          endpoint->device->heap_segment->mr, packet);
       if (rc == LCI_OK) {
         LCII_PCOUNTER_START(update_posted_recv);
 #ifdef LCI_ENABLE_MULTITHREAD_PROGRESS

--- a/lci/runtime/progress.c
+++ b/lci/runtime/progress.c
@@ -113,7 +113,7 @@ LCI_error_t LCII_fill_rq(LCII_endpoint_t* endpoint, bool block)
 
     // First, get a packet.
     LCII_PCOUNTER_START(get_recv_packet_timer);
-    LCII_packet_t* packet = LCII_alloc_packet_nb(g_pkpool);
+    LCII_packet_t* packet = LCII_alloc_packet_nb(endpoint->device->heap->pool);
     LCII_PCOUNTER_END(get_recv_packet_timer);
     if (packet == NULL) {
       LCII_PCOUNTER_ADD(net_recv_failed_nopacket, 1);

--- a/lci/runtime/rcache/lcii_rcache.c
+++ b/lci/runtime/rcache/lcii_rcache.c
@@ -30,9 +30,9 @@ static ucs_status_t LCII_rcache_mem_reg_cb(void* context, ucs_rcache_t* rcache,
 {
   LCII_rcache_entry_t* region = ucs_derived_of(rregion, LCII_rcache_entry_t);
   LCI_device_t device = context;
-  region->mr =
-      LCIS_rma_reg(device->server, (void*)region->super.super.start,
-                   region->super.super.end - region->super.super.start);
+  region->mr = LCIS_rma_reg(
+      device->endpoint_progress->endpoint, (void*)region->super.super.start,
+      region->super.super.end - region->super.super.start);
   return UCS_OK;
 }
 

--- a/lci/runtime/rendezvous.h
+++ b/lci/runtime/rendezvous.h
@@ -287,7 +287,7 @@ static inline void LCII_handle_rts(LCI_endpoint_t ep, LCII_packet_t* packet,
   LCII_PCOUNTER_START(rts_send_timer);
   LCIS_post_send_bq(ep->bq_p, ep->bq_spinlock_p, endpoint_to_use,
                     (int)rdv_ctx->rank, packet->data.address, length,
-                    ep->device->heap.segment->mr,
+                    ep->device->heap_segment->mr,
                     LCII_MAKE_PROTO(ep->gid, LCI_MSG_RTR, 0), rtr_ctx);
   LCII_PCOUNTER_END(rts_send_timer);
 }

--- a/lct/pcounter/pcounter.cpp
+++ b/lct/pcounter/pcounter.cpp
@@ -475,6 +475,8 @@ void record_thread_fn(ctx_t* ctx, uint64_t record_interval)
     else if (ctx->dump_record_on_the_fly) {
       ctx->record();
       ctx->dump(ctx->dump_ofile);
+    } else {
+      break;
     }
     usleep(record_interval);
   }


### PR DESCRIPTION
This PR includes two changes:
- All LCI devices share a single low-level `LCIS_server` data structure.
- All LCI devices share a single heap memory allocation and packet pool.

It fixes the performance anomaly that more LCI devices sometimes lead to worse application performance.