### PR TITLE
Remove the LCI::Shared cmake target

### DIFF
--- a/LCIConfig.cmake.in
+++ b/LCIConfig.cmake.in
@@ -29,14 +29,14 @@ if (NOT TARGET LCI::LCT)
         set_and_check(LCI_SHARED_LIBRARY "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@CMAKE_SHARED_LIBRARY_PREFIX@lci@CMAKE_SHARED_LIBRARY_SUFFIX@")
         # set_and_check(LCI_STATIC_LIBRARY "@PACKAGE_CMAKE_INSTALL_LIBDIR@/@CMAKE_STATIC_LIBRARY_PREFIX@lci@CMAKE_STATIC_LIBRARY_SUFFIX@")
 
-        add_library(LCI::Shared SHARED IMPORTED)
-        set_target_properties(LCI::Shared PROPERTIES
+        add_library(LCI::LCI SHARED IMPORTED)
+        set_target_properties(LCI::LCI PROPERTIES
           IMPORTED_LOCATION ${LCI_SHARED_LIBRARY}
         )
-        target_include_directories(LCI::Shared INTERFACE ${LCI_INCLUDE_DIRS})
-        target_link_libraries(LCI::Shared INTERFACE Threads::Threads @FABRIC@::@FABRIC@ LCI::LCT)
+        target_include_directories(LCI::LCI INTERFACE ${LCI_INCLUDE_DIRS})
+        target_link_libraries(LCI::LCI INTERFACE Threads::Threads @FABRIC@::@FABRIC@ LCI::LCT)
 
-        add_library(LCI::LCI ALIAS LCI::Shared)
+        # add_library(LCI::LCI ALIAS LCI::Shared)
 
         # add_library(LCI::Static STATIC IMPORTED)
         # set_target_properties(LCI::Static PROPERTIES


### PR DESCRIPTION
alias target can cause problems with cmake of lower version (such as 3.16).

> [build] CMake Error at /path/to/LCIConfig.cmake:63 (add_library):
> [build]   add_library cannot create ALIAS target "LCI::LCI" because target
> [build]   "LCI::Shared" is imported but not globally visible.

We could either raise the minimum cmake version (as high as 3.23) or just get rid of the alias target.

I chose the latter one as I don't think we need the `LCI::Shared` target.