### PR TITLE
fix lct spinlock on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,9 @@ if(NOT LCI_WITH_LCT_ONLY)
          "LCI_progress can be called by multiple threads simultaneously" ON)
   option(LCI_CONFIG_USE_ALIGNED_ALLOC "Enable memory alignment" ON)
   set(LCI_COMPILE_DREG_DEFAULT ON)
-  if(LCI_USE_SERVER_UCX)
+  if(LCI_USE_SERVER_UCX OR APPLE)
+    # Our UCS code can be non-compatible with external UCX. Some UCS code is not
+    # compatible with MacOS
     set(LCI_COMPILE_DREG_DEFAULT OFF)
   endif()
   set(LCI_COMPILE_DREG

--- a/cmake_modules/AddLCI.cmake
+++ b/cmake_modules/AddLCI.cmake
@@ -2,13 +2,15 @@ function(add_lci_executable name)
   add_executable(${name} ${ARGN})
   target_compile_definitions(${name} PRIVATE _GNU_SOURCE)
   target_link_libraries(${name} PRIVATE LCI)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
-    target_link_options(${name} PRIVATE LINKER:-z,now LINKER:-z,relro)
-  else()
-    set_property(
-      TARGET ${name}
-      APPEND_STRING
-      PROPERTY LINK_FLAGS " -Wl,-z,now -Wl,-z,relro")
+  if(NOT APPLE)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.13")
+      target_link_options(${name} PRIVATE LINKER:-z,now LINKER:-z,relro)
+    else()
+      set_property(
+        TARGET ${name}
+        APPEND_STRING
+        PROPERTY LINK_FLAGS " -Wl,-z,now -Wl,-z,relro")
+    endif()
   endif()
   set_target_properties(
     ${name}

--- a/lci/sys/lciu_malloc.h
+++ b/lci/sys/lciu_malloc.h
@@ -11,10 +11,15 @@ static inline void* LCIU_memalign(size_t alignment, size_t size)
 {
   void* p_ptr;
   int ret = posix_memalign(&p_ptr, alignment, size);
+#ifdef _SC_AVPHYS_PAGES
   LCI_Assert(
       ret == 0, "posix_memalign(%lu, %lu) returned %d (Free memory %lu/%lu)\n",
       alignment, size, ret, sysconf(_SC_AVPHYS_PAGES) * sysconf(_SC_PAGESIZE),
       sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE));
+#else
+  LCI_Assert(ret == 0, "posix_memalign(%lu, %lu) returned %d\n", alignment,
+             size, ret);
+#endif
   return p_ptr;
 }
 static inline void LCIU_free(void* ptr) { free(ptr); }

--- a/lct/api/lct.h
+++ b/lct/api/lct.h
@@ -25,6 +25,9 @@ LCT_API void LCT_set_rank(int rank);
 LCT_API int LCT_get_rank();
 
 // hostname
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
 extern char LCT_hostname[HOST_NAME_MAX + 1];
 
 // time

--- a/lct/lct.cpp
+++ b/lct/lct.cpp
@@ -30,10 +30,12 @@ void init()
       getenv("LCT_LOG_WHITELIST"), getenv("LCT_LOG_BLACKLIST"));
 
   // check cache size
+#ifdef _SC_LEVEL1_DCACHE_LINESIZE
   long cache_line_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
   LCT_Assert(LCT_log_ctx_default, LCT_CACHE_LINE == cache_line_size,
              "LCT_CACHE_LINE is set incorrectly! (%ld != %d)\n", LCT_CACHE_LINE,
              cache_line_size);
+#endif
 }
 
 void fina()

--- a/lct/util/spinlock.hpp
+++ b/lct/util/spinlock.hpp
@@ -8,18 +8,37 @@ namespace lct
 class spinlock_t
 {
  public:
-  spinlock_t() { pthread_spin_init(&l, PTHREAD_PROCESS_PRIVATE); }
+#ifdef __APPLE__
+  // Mac OS X doesn't support pthread_spinlock_t
+  // What makes it worse is that OSSpinLock is deprecated in Mac OS
+  // and in general spinlocks are not safe on Mac OS
+  // https://mjtsai.com/blog/2015/12/16/osspinlock-is-unsafe/
+  // so we use pthread_mutex_t instead
+  spinlock_t() { pthread_mutex_init(&m_lock, nullptr); }
+  ~spinlock_t() { pthread_mutex_destroy(&m_lock); }
 
-  ~spinlock_t() { pthread_spin_destroy(&l); }
+  bool try_lock() { return pthread_mutex_trylock(&m_lock); }
 
-  bool try_lock() { return pthread_spin_trylock(&l) == 0; }
+  void lock() { pthread_mutex_lock(&m_lock); }
 
-  void lock() { pthread_spin_lock(&l); }
-
-  void unlock() { pthread_spin_unlock(&l); }
+  void unlock() { pthread_mutex_unlock(&m_lock); }
 
  private:
-  pthread_spinlock_t l;
+  pthread_mutex_t m_lock;
+#else
+  spinlock_t() { pthread_spin_init(&m_lock, PTHREAD_PROCESS_PRIVATE); }
+
+  ~spinlock_t() { pthread_spin_destroy(&m_lock); }
+
+  bool try_lock() { return pthread_spin_trylock(&m_lock) == 0; }
+
+  void lock() { pthread_spin_lock(&m_lock); }
+
+  void unlock() { pthread_spin_unlock(&m_lock); }
+
+ private:
+  pthread_spinlock_t m_lock;
+#endif
 };
 }  // namespace lct
 


### PR DESCRIPTION
Apparently, `pthread_spinlock_t` does not exist on MacOS.

@ritvikrao Could you try whether PR this works for you?