### PR TITLE
Simplify the usage of status_t

### DIFF
--- a/benchmarks/resources/bench_cq.cpp
+++ b/benchmarks/resources/bench_cq.cpp
@@ -15,7 +15,7 @@ LCT_tbarrier_t g_tbarrier;
 
 void worker(int id, lci::comp_t cq) {
   lci::status_t dummy_status;
-  dummy_status.error = lci::errorcode_t::done;
+  dummy_status.set_done();
   LCT_tbarrier_arrive_and_wait(g_tbarrier);
   auto start = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < config.niters; i++) {

--- a/examples/pingpong_am_mt.cpp
+++ b/examples/pingpong_am_mt.cpp
@@ -50,13 +50,13 @@ void worker(int thread_id)
       do {
         lci::progress_x().device(device)();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
       if (status.tag != thread_id) {
         std::cerr << "thread_id: " << thread_id
                   << ", status.tag: " << status.tag << std::endl;
       }
       assert(status.tag == thread_id);
-      lci::buffer_t recv_buf = status.data.get_buffer();
+      lci::buffer_t recv_buf = status.get_buffer();
       assert(recv_buf.size == msg_size);
       for (size_t j = 0; j < msg_size; j++) {
         assert(((char*)recv_buf.base)[j] == peer_rank);
@@ -71,9 +71,9 @@ void worker(int thread_id)
       do {
         lci::progress_x().device(device)();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
       assert(status.tag == thread_id);
-      lci::buffer_t recv_buf = status.data.get_buffer();
+      lci::buffer_t recv_buf = status.get_buffer();
       assert(recv_buf.size == msg_size);
       for (size_t j = 0; j < msg_size; j++) {
         assert(((char*)recv_buf.base)[j] == peer_rank);

--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -521,6 +521,22 @@ struct status_t {
       : error(errorcode_t::done), user_context(user_context_)
   {
   }
+  void set_done() { error = errorcode_t::done; }
+  void set_posted() { error = errorcode_t::posted; }
+  void set_retry() { error = errorcode_t::retry; }
+  bool is_done() const { return error.is_done(); }
+  bool is_posted() const { return error.is_posted(); }
+  bool is_retry() const { return error.is_retry(); }
+  template <typename T>
+  T get_scalar() const
+  {
+    return data.get_scalar<T>();
+  }
+  buffer_t get_buffer() { return data.get_buffer(); }
+  buffers_t get_buffers() { return data.get_buffers(); }
+  bool is_scalar() const { return data.is_scalar(); }
+  bool is_buffer() const { return data.is_buffer(); }
+  bool is_buffers() const { return data.is_buffers(); }
 };
 
 /**

--- a/src/collective/collective.cpp
+++ b/src/collective/collective.cpp
@@ -365,7 +365,7 @@ void alltoall_x::call_impl(const void* sendbuf, void* recvbuf, size_t size,
                    .matching_engine(matching_engine)
                    .allow_done(false)();
       progress_x().runtime(runtime).device(device).endpoint(endpoint)();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     do {
       status = post_send_x(i, current_sendbuf, size, seqnum, comp)
                    .runtime(runtime)
@@ -374,7 +374,7 @@ void alltoall_x::call_impl(const void* sendbuf, void* recvbuf, size_t size,
                    .matching_engine(matching_engine)
                    .allow_done(false)();
       progress_x().runtime(runtime).device(device).endpoint(endpoint)();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
   }
 
   // sync_wait_x(comp, nullptr).runtime(runtime)();

--- a/src/comp/cq.hpp
+++ b/src/comp/cq.hpp
@@ -29,7 +29,7 @@ class cq_t : public comp_impl_t
   ~cq_t() { LCT_queue_free(&queue); }
   void signal(status_t status) override
   {
-    LCI_Assert(status.error.is_done(), "status.error is not done!\n");
+    LCI_Assert(status.is_done(), "status is not done!\n");
     LCI_PCOUNTER_ADD(comp_produce, 1);
     status_t* p = new status_t(std::move(status));
     LCT_queue_push(queue, p);
@@ -40,13 +40,13 @@ class cq_t : public comp_impl_t
     status_t status;
     status_t* p = static_cast<status_t*>(LCT_queue_pop(queue));
     if (p == nullptr) {
-      LCI_Assert(status.error.is_retry(), "status.error is not retry!\n");
+      LCI_Assert(status.is_retry(), "status is not retry!\n");
       return status;
     } else {
       status = std::move(*p);
       delete p;
       LCI_PCOUNTER_ADD(comp_consume, 1);
-      LCI_Assert(status.error.is_done(), "status.error is not done!\n");
+      LCI_Assert(status.is_done(), "status is not done!\n");
       return status;
     }
   }

--- a/src/comp/graph.hpp
+++ b/src/comp/graph.hpp
@@ -62,11 +62,10 @@ inline void graph_t::trigger_node(graph_node_t node_)
   if (node->fn) {
     status = node->fn(node->value);
   }
-  if (status.error.is_done()) {
+  if (status.is_done()) {
     mark_complete(node_, status);
   } else {
-    LCI_Assert(!status.error.is_retry(),
-               "The node function should not return retry");
+    LCI_Assert(!status.is_retry(), "The node function should not return retry");
   }
 }
 
@@ -104,7 +103,7 @@ inline void graph_t::mark_complete(graph_node_t node_, status_t status)
         comp_t comp = graph->m_comp;
         if (!comp.is_empty()) {
           status_t status;
-          status.error = errorcode_t::done;
+          status.set_done();
           status.user_context = graph->m_end_value;
           delete graph;
           comp.get_impl()->signal(status);
@@ -163,11 +162,11 @@ inline status_t graph_t::test()
 {
   status_t status;
   if (m_end_signals_remain.load(std::memory_order_relaxed) == 0) {
-    status.error = errorcode_t::done;
+    status.set_done();
     status.user_context = m_end_value;
     return status;
   } else {
-    status.error = errorcode_t::retry;
+    status.set_retry();
     return status;
   }
 }

--- a/src/core/communicate.cpp
+++ b/src/core/communicate.cpp
@@ -463,7 +463,7 @@ exit:
   }
   if (error.is_done() && !allow_done) {
     lci::comp_signal(local_comp, status);
-    status.error = errorcode_t::posted;
+    status.set_posted();
   }
   if (error.is_done()) {
     LCI_PCOUNTER_ADD(communicate_ok, 1);

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -39,7 +39,7 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
       if (entry.type == rhandler_registry_t::type_t::comp) {
         // we get an active message
         status_t status;
-        status.error = errorcode_t::done;
+        status.set_done();
         status.rank = net_status.rank;
         status.tag = tag;
         if (reinterpret_cast<comp_impl_t*>(entry.value)->attr.zero_copy_am) {
@@ -141,7 +141,7 @@ void progress_remote_write(runtime_t runtime, const net_status_t& net_status)
     remote_comp = get_bits32(imm_data, 15, 16);
     auto entry = runtime.get_impl()->default_rhandler_registry.get(remote_comp);
     status_t status;
-    status.error = errorcode_t::done;
+    status.set_done();
     status.rank = net_status.rank;
     status.tag = tag;
     status.user_context = nullptr;

--- a/src/core/protocol.hpp
+++ b/src/core/protocol.hpp
@@ -58,7 +58,7 @@ struct alignas(LCI_CACHE_LINE) internal_context_t {
   inline status_t get_status()
   {
     status_t status;
-    status.error = errorcode_t::done;
+    status.set_done();
     status.rank = rank;
     status.tag = tag;
     status.data = std::move(data);

--- a/src/core/rendezvous.hpp
+++ b/src/core/rendezvous.hpp
@@ -23,7 +23,7 @@ inline void handle_matched_sendrecv(runtime_t runtime, endpoint_t endpoint,
     comp_t comp = recv_ctx->comp;
 
     status_t status;
-    status.error = errorcode_t::done;
+    status.set_done();
     status.data = recv_ctx->data;
     status.user_context = recv_ctx->user_context;
     delete recv_ctx;

--- a/tests/unit/loopback/test_am.hpp
+++ b/tests/unit/loopback/test_am.hpp
@@ -26,21 +26,21 @@ TEST(COMM_AM, am_bcopy_st)
     do {
       status = lci::post_am(rank, &data, sizeof(data), lcq, rcomp);
       lci::progress();
-    } while (status.error.is_retry());
-    if (status.error.is_posted()) {
+    } while (status.is_retry());
+    if (status.is_posted()) {
       // poll local cq
       do {
         lci::progress();
         status = lci::cq_pop(lcq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
     // poll remote cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    } while (status.is_retry());
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
   }
 
   lci::free_comp(&lcq);
@@ -60,16 +60,16 @@ void test_am_bcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       status =
           lci::post_am_x(rank, p_data, sizeof(uint64_t), lcq, rcomp).tag(tag)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll cqs
-    bool lcq_done = status.error.is_done();
+    bool lcq_done = status.is_done();
     bool rcq_done = false;
     while (!lcq_done || !rcq_done) {
       lci::progress();
       if (!lcq_done) {
         status = lci::cq_pop(lcq);
-        if (status.error.is_done()) {
-          lci::buffer_t buffer = status.data.get_buffer();
+        if (status.is_done()) {
+          lci::buffer_t buffer = status.get_buffer();
           ASSERT_EQ(buffer.base, p_data);
           ASSERT_EQ(*(uint64_t*)buffer.base, *p_data);
           lcq_done = true;
@@ -77,8 +77,8 @@ void test_am_bcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       }
       if (!rcq_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), *p_data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), *p_data);
           rcq_done = true;
         }
       }
@@ -140,21 +140,21 @@ TEST(COMM_AM, am_zcopy_st)
       status = lci::post_am_x(rank, &data, sizeof(data), lcq, rcomp)
                    .force_zcopy(true)();
       lci::progress();
-    } while (status.error.is_retry());
-    if (status.error.is_posted()) {
+    } while (status.is_retry());
+    if (status.is_posted()) {
       // poll local cq
       do {
         lci::progress();
         status = lci::cq_pop(lcq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
     // poll remote cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    } while (status.is_retry());
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
   }
 
   lci::free_comp(&lcq);
@@ -175,16 +175,16 @@ void test_am_zcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
                    .tag(tag)
                    .force_zcopy(true)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll cqs
-    bool lcq_done = status.error.is_done();
+    bool lcq_done = status.is_done();
     bool rcq_done = false;
     while (!lcq_done || !rcq_done) {
       lci::progress();
       if (!lcq_done) {
         status = lci::cq_pop(lcq);
-        if (status.error.is_done()) {
-          lci::buffer_t buffer = status.data.get_buffer();
+        if (status.is_done()) {
+          lci::buffer_t buffer = status.get_buffer();
           ASSERT_EQ(buffer.base, p_data);
           ASSERT_EQ(*(uint64_t*)buffer.base, *p_data);
           lcq_done = true;
@@ -192,8 +192,8 @@ void test_am_zcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       }
       if (!rcq_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), *p_data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), *p_data);
           rcq_done = true;
         }
       }
@@ -261,15 +261,15 @@ TEST(COMM_AM, am_buffers_st)
     do {
       status = lci::post_am_x(rank, nullptr, 0, lcq, rcomp).buffers(buffers)();
       lci::progress();
-    } while (status.error.is_retry());
-    if (status.error.is_posted()) {
+    } while (status.is_retry());
+    if (status.is_posted()) {
       // poll local cq
       do {
         lci::progress();
         status = lci::cq_pop(lcq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, buffers[i].size);
@@ -279,8 +279,8 @@ TEST(COMM_AM, am_buffers_st)
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ret_buffers = status.data.get_buffers();
+    } while (status.is_retry());
+    ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, buffers[i].size);
@@ -307,16 +307,16 @@ void test_am_buffers_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
                    .tag(tag)
                    .buffers(buffers)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll cqs
-    bool lcq_done = status.error.is_done();
+    bool lcq_done = status.is_done();
     bool rcq_done = false;
     while (!lcq_done || !rcq_done) {
       lci::progress();
       if (!lcq_done) {
         status = lci::cq_pop(lcq);
-        if (status.error.is_done()) {
-          lci::buffers_t ret_buffers = status.data.get_buffers();
+        if (status.is_done()) {
+          lci::buffers_t ret_buffers = status.get_buffers();
           ASSERT_EQ(ret_buffers.size(), buffers.size());
           for (size_t i = 0; i < ret_buffers.size(); i++) {
             ASSERT_EQ(ret_buffers[i].size, buffers[i].size);
@@ -327,8 +327,8 @@ void test_am_buffers_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       }
       if (!rcq_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          lci::buffers_t ret_buffers = status.data.get_buffers();
+        if (status.is_done()) {
+          lci::buffers_t ret_buffers = status.get_buffers();
           ASSERT_EQ(ret_buffers.size(), buffers.size());
           for (size_t i = 0; i < ret_buffers.size(); i++) {
             ASSERT_EQ(ret_buffers[i].size, buffers[i].size);

--- a/tests/unit/loopback/test_backlog_queue.hpp
+++ b/tests/unit/loopback/test_backlog_queue.hpp
@@ -25,21 +25,21 @@ TEST(BACKLOG_QUEUE, am_bcopy_st_bq)
     lci::status_t status;
     status = lci::post_am_x(rank, &data, sizeof(data), lcq, rcomp)
                  .allow_retry(false)();
-    ASSERT_EQ(status.error.is_retry(), false);
-    if (status.error.is_posted()) {
+    ASSERT_EQ(status.is_retry(), false);
+    if (status.is_posted()) {
       // poll local cq
       do {
         lci::progress();
         status = lci::cq_pop(lcq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
     // poll remote cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    } while (status.is_retry());
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
   }
 
   lci::free_comp(&lcq);
@@ -58,16 +58,16 @@ void test_am_bcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
     status = lci::post_am_x(rank, p_data, sizeof(uint64_t), lcq, rcomp)
                  .tag(tag)
                  .allow_retry(false)();
-    ASSERT_EQ(status.error.is_retry(), false);
+    ASSERT_EQ(status.is_retry(), false);
     // poll cqs
-    bool lcq_done = status.error.is_done();
+    bool lcq_done = status.is_done();
     bool rcq_done = false;
     while (!lcq_done || !rcq_done) {
       lci::progress();
       if (!lcq_done) {
         status = lci::cq_pop(lcq);
-        if (status.error.is_done()) {
-          lci::buffer_t buffer = status.data.get_buffer();
+        if (status.is_done()) {
+          lci::buffer_t buffer = status.get_buffer();
           ASSERT_EQ(buffer.base, p_data);
           ASSERT_EQ(*(uint64_t*)buffer.base, *p_data);
           lcq_done = true;
@@ -75,8 +75,8 @@ void test_am_bcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       }
       if (!rcq_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), *p_data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), *p_data);
           rcq_done = true;
         }
       }
@@ -137,21 +137,21 @@ TEST(BACKLOG_QUEUE, am_zcopy_st_bq)
     status = lci::post_am_x(rank, &data, sizeof(data), lcq, rcomp)
                  .force_zcopy(true)
                  .allow_retry(false)();
-    ASSERT_EQ(status.error.is_retry(), false);
-    if (status.error.is_posted()) {
+    ASSERT_EQ(status.is_retry(), false);
+    if (status.is_posted()) {
       // poll local cq
       do {
         lci::progress();
         status = lci::cq_pop(lcq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
     // poll remote cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+    } while (status.is_retry());
+    ASSERT_EQ(status.get_scalar<uint64_t>(), data);
   }
 
   lci::free_comp(&lcq);
@@ -171,16 +171,16 @@ void test_am_zcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
                  .tag(tag)
                  .force_zcopy(true)
                  .allow_retry(false)();
-    ASSERT_EQ(status.error.is_retry(), false);
+    ASSERT_EQ(status.is_retry(), false);
     // poll cqs
-    bool lcq_done = status.error.is_done();
+    bool lcq_done = status.is_done();
     bool rcq_done = false;
     while (!lcq_done || !rcq_done) {
       lci::progress();
       if (!lcq_done) {
         status = lci::cq_pop(lcq);
-        if (status.error.is_done()) {
-          lci::buffer_t buffer = status.data.get_buffer();
+        if (status.is_done()) {
+          lci::buffer_t buffer = status.get_buffer();
           ASSERT_EQ(buffer.base, p_data);
           ASSERT_EQ(*(uint64_t*)buffer.base, *p_data);
           lcq_done = true;
@@ -188,8 +188,8 @@ void test_am_zcopy_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       }
       if (!rcq_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), *p_data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), *p_data);
           rcq_done = true;
         }
       }
@@ -257,14 +257,14 @@ TEST(BACKLOG_QUEUE, am_buffers_st_bq)
     status = lci::post_am_x(rank, nullptr, 0, lcq, rcomp)
                  .buffers(buffers)
                  .allow_retry(false)();
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll local cq
       do {
         lci::progress();
         status = lci::cq_pop(lcq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, buffers[i].size);
@@ -274,8 +274,8 @@ TEST(BACKLOG_QUEUE, am_buffers_st_bq)
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ret_buffers = status.data.get_buffers();
+    } while (status.is_retry());
+    ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, buffers[i].size);
@@ -302,14 +302,14 @@ void test_am_buffers_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
                  .buffers(buffers)
                  .allow_retry(false)();
     // poll cqs
-    bool lcq_done = status.error.is_done();
+    bool lcq_done = status.is_done();
     bool rcq_done = false;
     while (!lcq_done || !rcq_done) {
       lci::progress();
       if (!lcq_done) {
         status = lci::cq_pop(lcq);
-        if (status.error.is_done()) {
-          lci::buffers_t ret_buffers = status.data.get_buffers();
+        if (status.is_done()) {
+          lci::buffers_t ret_buffers = status.get_buffers();
           ASSERT_EQ(ret_buffers.size(), buffers.size());
           for (size_t i = 0; i < ret_buffers.size(); i++) {
             ASSERT_EQ(ret_buffers[i].size, buffers[i].size);
@@ -320,8 +320,8 @@ void test_am_buffers_mt(int id, int nmsgs, lci::comp_t lcq, lci::comp_t rcq,
       }
       if (!rcq_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          lci::buffers_t ret_buffers = status.data.get_buffers();
+        if (status.is_done()) {
+          lci::buffers_t ret_buffers = status.get_buffers();
           ASSERT_EQ(ret_buffers.size(), buffers.size());
           for (size_t i = 0; i < ret_buffers.size(); i++) {
             ASSERT_EQ(ret_buffers[i].size, buffers[i].size);

--- a/tests/unit/loopback/test_cq.hpp
+++ b/tests/unit/loopback/test_cq.hpp
@@ -6,7 +6,7 @@ namespace test_cq
 void my_cq_push(lci::comp_t comp, uint64_t i)
 {
   lci::status_t status;
-  status.error = lci::errorcode_t::done;
+  status.set_done();
   status.user_context = reinterpret_cast<void*>(i + 1);
   lci::comp_signal(comp, status);
 }
@@ -16,7 +16,7 @@ uint64_t my_cq_pop(lci::comp_t comp)
   lci::status_t status;
   do {
     status = lci::cq_pop(comp);
-  } while (status.error.is_retry());
+  } while (status.is_retry());
   return reinterpret_cast<uint64_t>(status.user_context) - 1;
 }
 

--- a/tests/unit/loopback/test_get.hpp
+++ b/tests/unit/loopback/test_get.hpp
@@ -32,13 +32,13 @@ TEST(COMM_GET, get_bcopy_st)
       status = lci::post_get(rank, recv_buffer, msg_size, cq,
                              reinterpret_cast<uintptr_t>(send_buffer), rkey);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -73,13 +73,13 @@ void test_get_bcopy_mt(int id, int nmsgs, uint64_t* p_data)
       status = lci::post_get(rank, recv_buffer, msg_size, cq,
                              reinterpret_cast<uintptr_t>(send_buffer), rkey);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -143,13 +143,13 @@ TEST(COMM_GET, get_zcopy_st)
       status = lci::post_get(rank, recv_buffer, msg_size, cq,
                              reinterpret_cast<uintptr_t>(send_buffer), rkey);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -182,13 +182,13 @@ void test_get_zcopy_mt(int id, int nmsgs)
       status = lci::post_get(rank, recv_buffer, msg_size, cq,
                              reinterpret_cast<uintptr_t>(send_buffer), rkey);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -259,17 +259,17 @@ TEST(COMM_GET, get_buffers_st)
                    .buffers(recv_buffers)
                    .rbuffers(rbuffers)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll cq
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // verify the result
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), recv_buffers.size());
     for (auto& buffer : recv_buffers) {
       ASSERT_EQ(buffer.size, msg_size);
@@ -315,17 +315,17 @@ void test_get_buffers_mt(int id, int nmsgs)
                    .buffers(recv_buffers)
                    .rbuffers(rbuffers)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll cq
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // verify the result
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), recv_buffers.size());
     for (auto& buffer : recv_buffers) {
       ASSERT_EQ(buffer.size, msg_size);

--- a/tests/unit/loopback/test_matching_policy.hpp
+++ b/tests/unit/loopback/test_matching_policy.hpp
@@ -22,12 +22,12 @@ TEST(MATCHING_POLICY, test_rank_tag)
   for (int i = 0; i < n; ++i) {
     lci::status_t status =
         lci::post_send(0, &data, sizeof(data), in[i], lci::COMP_NULL_EXPECT_OK);
-    ASSERT_EQ(status.error.is_done(), true);
+    ASSERT_EQ(status.is_done(), true);
   }
   for (int i = 0; i < n; ++i) {
     lci::status_t status =
         lci::post_recv(0, &data, sizeof(data), in[i], lci::COMP_NULL_EXPECT_OK);
-    ASSERT_EQ(status.error.is_done(), true);
+    ASSERT_EQ(status.is_done(), true);
     ASSERT_EQ(status.tag, in[i]);
   }
 
@@ -53,14 +53,14 @@ TEST(MATCHING_POLICY, test_rank_only)
         lci::post_send_x(0, &data, sizeof(data), in[i],
                          lci::COMP_NULL_EXPECT_OK)
             .matching_policy(lci::matching_policy_t::rank_only)();
-    ASSERT_EQ(status.error.is_done(), true);
+    ASSERT_EQ(status.is_done(), true);
   }
   bool flags[n];
   memset(flags, false, sizeof(flags));
   for (int i = 0; i < n; ++i) {
     lci::status_t status = lci::post_recv(0, &data, sizeof(data), lci::ANY_TAG,
                                           lci::COMP_NULL_EXPECT_OK);
-    ASSERT_EQ(status.error.is_done(), true);
+    ASSERT_EQ(status.is_done(), true);
     int idx = status.tag;
     ASSERT_EQ(idx >= 0 && idx < n, true);
     ASSERT_EQ(flags[idx], false);
@@ -91,7 +91,7 @@ TEST(MATCHING_POLICY, test_none)
     lci::status_t status = lci::post_send_x(0, &data, sizeof(data), in[i],
                                             lci::COMP_NULL_EXPECT_OK)
                                .matching_policy(lci::matching_policy_t::none)();
-    ASSERT_EQ(status.error.is_done(), true);
+    ASSERT_EQ(status.is_done(), true);
   }
   bool flags[n];
   memset(flags, false, sizeof(flags));
@@ -99,7 +99,7 @@ TEST(MATCHING_POLICY, test_none)
     lci::status_t status =
         lci::post_recv(lci::ANY_SOURCE, &data, sizeof(data), lci::ANY_TAG,
                        lci::COMP_NULL_EXPECT_OK);
-    ASSERT_EQ(status.error.is_done(), true);
+    ASSERT_EQ(status.is_done(), true);
     ASSERT_EQ(status.rank, 0);
     int idx = status.tag;
     ASSERT_EQ(idx >= 0 && idx < n, true);

--- a/tests/unit/loopback/test_put.hpp
+++ b/tests/unit/loopback/test_put.hpp
@@ -33,13 +33,13 @@ TEST(COMM_PUT, put_bcopy_st)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .comp_semantic(lci::comp_semantic_t::network)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -75,13 +75,13 @@ void test_put_bcopy_mt(int id, int nmsgs, uint64_t* p_data)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .comp_semantic(lci::comp_semantic_t::network)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -146,13 +146,13 @@ TEST(COMM_PUT, put_zcopy_st)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .comp_semantic(lci::comp_semantic_t::network)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -186,13 +186,13 @@ void test_put_zcopy_mt(int id, int nmsgs)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .comp_semantic(lci::comp_semantic_t::network)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
 
     util::check_buffer(recv_buffer, msg_size, 'a');
@@ -264,17 +264,17 @@ TEST(COMM_PUT, put_buffers_st)
                    .rbuffers(rbuffers)
                    .comp_semantic(lci::comp_semantic_t::network)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll cq
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // verify the result
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), send_buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, send_buffers[i].size);
@@ -325,17 +325,17 @@ void test_put_buffers_mt(int id, int nmsgs)
                    .rbuffers(rbuffers)
                    .comp_semantic(lci::comp_semantic_t::network)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll cq
       do {
         lci::progress();
         status = lci::cq_pop(cq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // verify the result
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), send_buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, send_buffers[i].size);

--- a/tests/unit/loopback/test_putImm.hpp
+++ b/tests/unit/loopback/test_putImm.hpp
@@ -35,19 +35,19 @@ TEST(COMM_PUTIMM, putImm_bcopy_st)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .remote_comp(rcomp)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll send cq
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll receive cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     util::check_buffer(recv_buffer, msg_size, 'a');
   }
   // clean up
@@ -87,19 +87,19 @@ void test_putImm_bcopy_mt(int id, int nmsgs, uint64_t* p_data,
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .remote_comp(rcomp)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll send cq
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll receive cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     util::check_buffer(recv_buffer, msg_size, 'a');
   }
   // clean up
@@ -168,19 +168,19 @@ TEST(COMM_PUTIMM, putImm_zcopy_st)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .remote_comp(rcomp)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll send cq
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll receive cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     util::check_buffer(recv_buffer, msg_size, 'a');
   }
   // clean up
@@ -219,19 +219,19 @@ void test_putImm_zcopy_mt(int id, int nmsgs, lci::rcomp_t rcomp_base)
                                reinterpret_cast<uintptr_t>(recv_buffer), rkey)
                    .remote_comp(rcomp)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // poll send cq
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll receive cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     util::check_buffer(recv_buffer, msg_size, 'a');
   }
   // clean up
@@ -307,20 +307,20 @@ TEST(COMM_PUTIMM, putImm_buffers_st)
                    .tag(i)
                    .remote_comp(rcomp)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll send cq
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll receive cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // verify the result
     ASSERT_EQ(status.tag, i);
     for (auto& buffer : recv_buffers) {
@@ -375,20 +375,20 @@ void test_putImm_buffers_mt(int id, int nmsgs, lci::rcomp_t rcomp_base)
                    .tag(i)
                    .remote_comp(rcomp)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll send cq
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll receive cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     // verify the result
     ASSERT_EQ(status.tag, i);
     for (auto& buffer : recv_buffers) {

--- a/tests/unit/loopback/test_sendrecv.hpp
+++ b/tests/unit/loopback/test_sendrecv.hpp
@@ -24,15 +24,15 @@ TEST(COMM_SENDRECV, sendrecv_bcopy_st)
     do {
       status = lci::post_recv(rank, &data, sizeof(data), 0, rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
     do {
       status = lci::post_send(rank, &data, sizeof(data), 0, scq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
     bool send_done = false, recv_done = false;
-    if (status.error.is_done()) {
+    if (status.is_done()) {
       send_done = true;
     }
 
@@ -40,15 +40,15 @@ TEST(COMM_SENDRECV, sendrecv_bcopy_st)
       lci::progress();
       if (!send_done) {
         status = lci::cq_pop(scq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), data);
           send_done = true;
         }
       }
       if (!recv_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), data);
           recv_done = true;
         }
       }
@@ -73,15 +73,15 @@ void test_sendrecv_bcopy_mt(int id, int nmsgs, uint64_t* p_data)
     do {
       status = lci::post_recv(rank, p_data, sizeof(uint64_t), id, rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
     do {
       status = lci::post_send(rank, p_data, sizeof(uint64_t), id, scq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
     bool send_done = false, recv_done = false;
-    if (status.error.is_done()) {
+    if (status.is_done()) {
       send_done = true;
     }
 
@@ -89,15 +89,15 @@ void test_sendrecv_bcopy_mt(int id, int nmsgs, uint64_t* p_data)
       lci::progress();
       if (!send_done) {
         status = lci::cq_pop(scq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), *p_data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), *p_data);
           send_done = true;
         }
       }
       if (!recv_done) {
         status = lci::cq_pop(rcq);
-        if (status.error.is_done()) {
-          ASSERT_EQ(status.data.get_scalar<uint64_t>(), *p_data);
+        if (status.is_done()) {
+          ASSERT_EQ(status.get_scalar<uint64_t>(), *p_data);
           recv_done = true;
         }
       }
@@ -158,24 +158,24 @@ TEST(COMM_SENDRECV, sendrecv_zcopy_st)
     do {
       status = lci::post_recv(rank, recv_buffer, msg_size, i, rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     do {
       status = lci::post_send(rank, send_buffer, msg_size, i, scq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll send cq
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll recv cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     util::check_buffer(recv_buffer, msg_size, 'a');
   }
 
@@ -204,24 +204,24 @@ void test_sendrecv_zcopy_mt(int id, int nmsgs)
     do {
       status = lci::post_recv(rank, recv_buffer, msg_size, id, rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     do {
       status = lci::post_send(rank, send_buffer, msg_size, id, scq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
 
-    if (status.error.is_posted()) {
+    if (status.is_posted()) {
       // poll send cq
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
     // poll recv cq
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     util::check_buffer(recv_buffer, msg_size, 'a');
   }
 
@@ -289,20 +289,20 @@ TEST(COMM_SENDRECV, sendrecv_buffers_st)
       status =
           lci::post_recv_x(rank, nullptr, 0, i, rcq).buffers(recv_buffers)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     do {
       status =
           lci::post_send_x(rank, nullptr, 0, i, scq).buffers(send_buffers)();
       lci::progress();
-    } while (status.error.is_retry());
-    if (status.error.is_posted()) {
+    } while (status.is_retry());
+    if (status.is_posted()) {
       // poll send cq
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), send_buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, send_buffers[i].size);
@@ -312,8 +312,8 @@ TEST(COMM_SENDRECV, sendrecv_buffers_st)
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ret_buffers = status.data.get_buffers();
+    } while (status.is_retry());
+    ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), recv_buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, recv_buffers[i].size);
@@ -355,20 +355,20 @@ void test_sendrecv_buffers_mt(int id, int nmsgs)
       status =
           lci::post_recv_x(rank, nullptr, 0, id, rcq).buffers(recv_buffers)();
       lci::progress();
-    } while (status.error.is_retry());
+    } while (status.is_retry());
     do {
       status =
           lci::post_send_x(rank, nullptr, 0, id, scq).buffers(send_buffers)();
       lci::progress();
-    } while (status.error.is_retry());
-    if (status.error.is_posted()) {
+    } while (status.is_retry());
+    if (status.is_posted()) {
       // poll send cq
       do {
         lci::progress();
         status = lci::cq_pop(scq);
-      } while (status.error.is_retry());
+      } while (status.is_retry());
     }
-    lci::buffers_t ret_buffers = status.data.get_buffers();
+    lci::buffers_t ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), send_buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, send_buffers[i].size);
@@ -378,8 +378,8 @@ void test_sendrecv_buffers_mt(int id, int nmsgs)
     do {
       status = lci::cq_pop(rcq);
       lci::progress();
-    } while (status.error.is_retry());
-    ret_buffers = status.data.get_buffers();
+    } while (status.is_retry());
+    ret_buffers = status.get_buffers();
     ASSERT_EQ(ret_buffers.size(), recv_buffers.size());
     for (size_t i = 0; i < ret_buffers.size(); i++) {
       ASSERT_EQ(ret_buffers[i].size, recv_buffers[i].size);

--- a/tests/unit/loopback/test_sync.hpp
+++ b/tests/unit/loopback/test_sync.hpp
@@ -6,7 +6,7 @@ namespace test_sync
 void my_sync_signal(lci::comp_t comp, uint64_t i)
 {
   lci::status_t status;
-  status.error = lci::errorcode_t::done;
+  status.set_done();
   status.user_context = reinterpret_cast<void*>(i + 1);
   lci::comp_signal(comp, status);
 }


### PR DESCRIPTION
Defining convenience wrappers:
- `is/set_done`
- `is/set_retry`
- `is/set_posted`
- `is/get_scalar`
- `is/get_buffer`
- `is/get_buffers`