### PR TITLE
Improve resource benchmark

### DIFF
--- a/benchmarks/resources/CMakeLists.txt
+++ b/benchmarks/resources/CMakeLists.txt
@@ -12,4 +12,4 @@ function(add_lci_bench_resources)
 endfunction()
 
 add_lci_bench_resources(bench_packet_pool.cpp bench_matching_engine.cpp
-                        bench_cq.cpp bench_memory.cpp)
+                        bench_cq.cpp bench_malloc.cpp bench_memcpy.cpp)

--- a/benchmarks/resources/bench_cq.cpp
+++ b/benchmarks/resources/bench_cq.cpp
@@ -5,6 +5,8 @@
 #include "lct.h"
 #include "lci.hpp"
 
+#include "util.hpp"
+
 struct config_t {
   int nthreads = 16;
   int niters = 1000;
@@ -14,6 +16,7 @@ struct config_t {
 LCT_tbarrier_t g_tbarrier;
 
 void worker(int id, lci::comp_t cq) {
+  util::pin_thread_to_cpu(id);
   lci::status_t dummy_status;
   dummy_status.set_done();
   LCT_tbarrier_arrive_and_wait(g_tbarrier);

--- a/benchmarks/resources/bench_cq.cpp
+++ b/benchmarks/resources/bench_cq.cpp
@@ -26,7 +26,10 @@ void worker(int id, lci::comp_t cq) {
       lci::comp_signal(cq, dummy_status);
     }
     for (int j = config.window - 1; j >= 0; j--) {
-      lci::cq_pop(cq);
+      lci::status_t status;
+      do {
+        status = lci::cq_pop(cq);
+      } while (status.is_retry());
     }
   }
   LCT_tbarrier_arrive_and_wait(g_tbarrier);

--- a/benchmarks/resources/bench_memcpy.cpp
+++ b/benchmarks/resources/bench_memcpy.cpp
@@ -5,39 +5,32 @@
 #include "lct.h"
 #include "lci.hpp"
 
+#include "util.hpp"
+
 struct config_t {
   int nthreads = 16;
-  int niters = 1000;
-  int window = 1;
-  int nbytes = 64;
-  int copy = 0;
+  int niters = 1;
+  size_t total_size = 1024 * 1024 * 1024; // Total size in bytes
+  int block_size = 64;
 } config;
 
 LCT_tbarrier_t g_tbarrier;
-void *data;
+
+char *src_buffer;
+char *dst_buffer;
 
 void worker(int id) {
-  std::vector<void*> buffers(config.window);
+  util::pin_thread_to_cpu(id);
+  size_t total_accesses = config.total_size / config.block_size;
+  size_t accesses_per_thread = total_accesses / config.nthreads;
+  size_t start_access = id * accesses_per_thread;
   LCT_tbarrier_arrive_and_wait(g_tbarrier);
   auto start = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < config.niters; i++) {
-    for (int j = 0; j < config.window; j++) {
-      void *ret = malloc(config.nbytes);
-      if (ret == nullptr) {
-        fprintf(stderr, "malloc failed\n");
-        exit(1);
-      }
-      if (config.copy == 1) {
-        // no cache miss
-        memcpy(ret, data, config.nbytes);
-      } else if (config.copy == 2) {
-        // cache miss
-        memcpy(data, ret, config.nbytes);
-      }
-      buffers[j] = ret;
-    }
-    for (int j = config.window - 1; j >= 0; j--) {
-      free(buffers[j]);
+    for (int j = 0; j < accesses_per_thread; j++) {
+      size_t access = start_access + j;
+      size_t offset = access * config.block_size;
+      memcpy(dst_buffer + offset, src_buffer + offset, config.block_size);
     }
   }
   LCT_tbarrier_arrive_and_wait(g_tbarrier);
@@ -47,36 +40,45 @@ void worker(int id) {
   if (id == 0) {
     printf("Elapsed time: %.2f s\n", elapsed_s);
     printf("Per-operation time: %.2f us\n",
-           (elapsed_s * 1e6) / (config.niters * config.window));
-    double throughput_per_thread = (static_cast<double>(config.niters) * config.window) / (elapsed_s * 1e6);
+           (elapsed_s * 1e6) / (config.niters * accesses_per_thread));
+    double throughput_per_thread = (static_cast<double>(config.niters) * accesses_per_thread) / (elapsed_s * 1e6);
     printf("Throughput per thread: %.2f Mops/s\n",
            throughput_per_thread);
     printf("Throughput: %.2f Mops/s\n", throughput_per_thread * config.nthreads);
     printf("Bandwidth per thread: %.2f GB/s\n",
-           (throughput_per_thread * config.nbytes) / 1e3);
+           (throughput_per_thread * config.block_size) / 1e3);
     printf("Bandwidth: %.2f GB/s\n",
-           (throughput_per_thread * config.nthreads * config.nbytes) / 1e3);
+           (throughput_per_thread * config.nthreads * config.block_size) / 1e3);
   }
 }
 
 int main(int argc, char** argv) {
+  int total_size_mb = config.total_size / (1024 * 1024);
   LCT_args_parser_t argsParser = LCT_args_parser_alloc();
   LCT_args_parser_add(argsParser, "nthreads", required_argument,
     &config.nthreads);
   LCT_args_parser_add(argsParser, "niters", required_argument,
       &config.niters);
-  LCT_args_parser_add(argsParser, "window", required_argument,
-      &config.window);
-  LCT_args_parser_add(argsParser, "nbytes", required_argument,
-      &config.nbytes);
-  LCT_args_parser_add(argsParser, "copy", required_argument,
-      &config.copy);
+  LCT_args_parser_add(argsParser, "total-size", required_argument,
+      &total_size_mb);
+  LCT_args_parser_add(argsParser, "block-size", required_argument,
+      &config.block_size);
   LCT_args_parser_parse(argsParser, argc, argv);
   LCT_args_parser_print(argsParser, true);
   LCT_args_parser_free(argsParser);
 
+  config.total_size = static_cast<size_t>(total_size_mb) * 1024 * 1024; // Convert to bytes
   g_tbarrier = LCT_tbarrier_alloc(config.nthreads);
-  data = malloc(config.nbytes);
+  src_buffer = static_cast<char*>(aligned_alloc(4096, config.total_size));
+  if (src_buffer == nullptr) {
+    fprintf(stderr, "malloc failed\n");
+    exit(1);
+  }
+  dst_buffer = static_cast<char*>(aligned_alloc(4096, config.total_size));
+  if (dst_buffer == nullptr) {
+    fprintf(stderr, "malloc failed\n");
+    exit(1);
+  }
 
   lci::g_runtime_init();
 
@@ -88,9 +90,11 @@ int main(int argc, char** argv) {
   for (auto& t : threads) {
     t.join();
   }
-  free(data);
 
   lci::g_runtime_fina();
+
+  free(src_buffer);
+  free(dst_buffer);
 
   LCT_tbarrier_free(&g_tbarrier);
   return 0;

--- a/benchmarks/resources/bench_packet_pool.cpp
+++ b/benchmarks/resources/bench_packet_pool.cpp
@@ -5,6 +5,8 @@
 #include "lct.h"
 #include "lci.hpp"
 
+#include "util.hpp"
+
 struct config_t {
   int nthreads = 16;
   int niters = 1000;
@@ -14,6 +16,7 @@ struct config_t {
 LCT_tbarrier_t g_tbarrier;
 
 void worker(int id) {
+  util::pin_thread_to_cpu(id);
   std::vector<void*> packets(config.window);
   LCT_tbarrier_arrive_and_wait(g_tbarrier);
   auto start = std::chrono::high_resolution_clock::now();

--- a/benchmarks/resources/util.hpp
+++ b/benchmarks/resources/util.hpp
@@ -1,0 +1,13 @@
+namespace util {
+// TODO: Simplify the thread spawning and pinning
+void pin_thread_to_cpu(size_t cpu_id) {
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  CPU_SET(cpu_id, &cpuset);
+  pthread_t current_thread = pthread_self();
+  int rc = pthread_setaffinity_np(current_thread, sizeof(cpu_set_t), &cpuset);
+  if (rc != 0) {
+    fprintf(stderr, "Error setting CPU affinity for thread %zu: %d\n", cpu_id, rc);
+  }
+}
+} // namespace util

--- a/benchmarks/resources/util.hpp
+++ b/benchmarks/resources/util.hpp
@@ -1,6 +1,8 @@
 namespace util {
 // TODO: Simplify the thread spawning and pinning
 void pin_thread_to_cpu(size_t cpu_id) {
+  // macOS does not support CPU affinity setting
+  #ifndef __APPLE__
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(cpu_id, &cpuset);
@@ -9,5 +11,6 @@ void pin_thread_to_cpu(size_t cpu_id) {
   if (rc != 0) {
     fprintf(stderr, "Error setting CPU affinity for thread %zu: %d\n", cpu_id, rc);
   }
+#endif
 }
 } // namespace util

--- a/lct/data_structure/queue/queue.cpp
+++ b/lct/data_structure/queue/queue.cpp
@@ -12,6 +12,14 @@
 
 LCT_queue_t LCT_queue_alloc(LCT_queue_type_t type, size_t length)
 {
+#ifdef __APPLE__
+  if (type == LCT_QUEUE_LCRQ || type == LCT_QUEUE_LPRQ) {
+    LCT_Log(LCT_log_ctx_default, LCT_LOG_INFO, "queue",
+            "LCRQueue and LPRQueue are not supported on Apple platforms; "
+            "switching to FAAArrayQueue");
+    type = LCT_QUEUE_ARRAY_ATOMIC_FAA;
+  }
+#endif
   lct::queue_base_t* q;
   switch (type) {
     case LCT_QUEUE_ARRAY_ATOMIC_FAA:

--- a/src/binding/input/comp.py
+++ b/src/binding/input/comp.py
@@ -11,9 +11,10 @@ resource_comp := resource(
     "comp", 
     [
         attr_enum("comp_type", enum_options=["sync", "cq", "handler", "graph"], default_value="cq", comment="The completion object type.", inout_trait="out"),
-        attr("int", "sync_threshold", default_value=1, comment="The threshold for sync (synchronizer).", inout_trait="out"),
+        attr("int", "sync_threshold", default_value=1, comment="The threshold for sync (synchronizer)."),
         attr("bool", "zero_copy_am", default_value="false", comment="Whether to directly pass internal packet into the completion object."),
-        attr_enum("cq_type", enum_options=["array_atomic", "lcrq"], default_value="lcrq", comment="The completion object type."),
+        attr_enum("cq_type", enum_options=["array_atomic", "lcrq"], default_value="array_atomic", comment="The completion object type."),
+        attr("int", "cq_default_length", default_value=65536, comment="The default length of the completion queue."),
     ],
     doc = {
         "in_group": "LCI_COMPLETION",
@@ -74,8 +75,8 @@ operation(
     "alloc_sync", 
     [
         optional_runtime_args,
-        optional_arg("int", "threshold", 1, comment="The signaling threshold of the synchronizer."),
-        optional_arg("bool", "zero_copy_am", "false", comment="Whether to directly pass internal packet into the completion object."),
+        optional_arg("int", "threshold", "g_default_attr.sync_threshold", comment="The signaling threshold of the synchronizer."),
+        optional_arg("bool", "zero_copy_am", "g_default_attr.zero_copy_am", comment="Whether to directly pass internal packet into the completion object."),
         optional_arg("void*", "user_context", "nullptr", comment="The abitrary user-defined context associated with this completion object."),
         return_val("comp_t", "comp", comment="The allocated synchronizer.")
     ],
@@ -114,9 +115,9 @@ operation(
     "alloc_cq", 
     [
         optional_runtime_args,
-        optional_arg("int", "default_length", "65536", comment="The default length of the completion queue."),
-        optional_arg("bool", "zero_copy_am", "false", comment="Whether to directly pass internal packet into the completion object."),
-        optional_arg("attr_cq_type_t", "cq_type", "attr_cq_type_t::array_atomic", comment="The type of the completion queue."),
+        optional_arg("int", "default_length", "g_default_attr.cq_default_length", comment="The default length of the completion queue."),
+        optional_arg("bool", "zero_copy_am", "g_default_attr.zero_copy_am", comment="Whether to directly pass internal packet into the completion object."),
+        optional_arg("attr_cq_type_t", "cq_type", "g_default_attr.cq_type", comment="The type of the completion queue."),
         optional_arg("void*", "user_context", "nullptr", comment="The abitrary user-defined context associated with this completion object."),
         return_val("comp_t", "comp", comment="The allocated completion queue.")
     ],
@@ -144,7 +145,7 @@ operation(
     [
         optional_runtime_args,
         positional_arg("comp_handler_t", "handler", comment="The handler function."),
-        optional_arg("bool", "zero_copy_am", "false", comment="Whether to directly pass internal packet into the completion object."),
+        optional_arg("bool", "zero_copy_am", "g_default_attr.zero_copy_am", comment="Whether to directly pass internal packet into the completion object."),
         optional_arg("void*", "user_context", "nullptr", comment="The abitrary user-defined context associated with this completion object."),
         return_val("comp_t", "comp", comment="The allocated completion handler.")
     ],

--- a/src/binding/input/comp.py
+++ b/src/binding/input/comp.py
@@ -13,7 +13,7 @@ resource_comp := resource(
         attr_enum("comp_type", enum_options=["sync", "cq", "handler", "graph"], default_value="cq", comment="The completion object type.", inout_trait="out"),
         attr("int", "sync_threshold", default_value=1, comment="The threshold for sync (synchronizer)."),
         attr("bool", "zero_copy_am", default_value="false", comment="Whether to directly pass internal packet into the completion object."),
-        attr_enum("cq_type", enum_options=["array_atomic", "lcrq"], default_value="array_atomic", comment="The completion object type."),
+        attr_enum("cq_type", enum_options=["array_atomic", "lcrq"], default_value="lcrq", comment="The completion object type."),
         attr("int", "cq_default_length", default_value=65536, comment="The default length of the completion queue."),
     ],
     doc = {


### PR DESCRIPTION
- add `bench_malloc` and `bench_memcpy`.
- Pin benchmarking threads.
- bench_cq: keep popping until success.

Flyby: Change the default cq_type to `lcrq`.
