### PR TITLE
Enable HCA selection through device_name

### DIFF
--- a/src/binding/input/basic.py
+++ b/src/binding/input/basic.py
@@ -38,7 +38,14 @@ resource_runtime := resource(
         "brief": "The runtime object.",
     }
 ),
-op_alloc_runtime := operation_alloc(resource_runtime, add_runtime_args=False, init_global=True),
+op_alloc_runtime := operation_alloc(
+    resource_runtime,
+    [
+        optional_arg("std::string", "device_name", "g_default_attr.device_name", comment="The network device name to use for the default network context."),
+    ],
+    add_runtime_args=False,
+    init_global=True
+),
 operation_free(resource_runtime, add_runtime_args=False, fina_global=True),
 operation(
     "g_runtime_init",

--- a/src/binding/input/network.py
+++ b/src/binding/input/network.py
@@ -19,6 +19,7 @@ resource_net_context := resource(
         attr("size_t", "max_inject_size", default_value=64, comment="The maximum inject size."),
         attr("int", "ibv_gid_idx", default_value=-1, comment="For the IBV backend: the GID index by default (only needed by RoCE)."),
         attr("bool", "ibv_force_gid_auto_select", default_value=0, comment="For the IBV backend: whether to force GID auto selection."),
+        attr("std::string", "device_name", default_value="\"\"", comment="The network device name to use. For the IBV backend this is the verbs device name; for the OFI backend this is the libfabric domain name. Empty string selects the default/best available device."),
         attr_enum("ibv_odp_strategy", enum_options=["none", "explicit_odp", "implicit_odp"], default_value="none", comment="For the IBV backend: the on-demand paging strategy."),
         attr_enum("ibv_prefetch_strategy", enum_options=["none", "prefetch", "prefetch_write", "prefetch_no_fault"], default_value="none", comment="For the IBV backend: the mr prefetch strategy."),
         attr("bool", "support_putimm", inout_trait="out", comment="Whether the network context supports put with immediate data."),

--- a/src/network/ibv/backend_ibv.cpp
+++ b/src/network/ibv/backend_ibv.cpp
@@ -54,6 +54,7 @@ ibv_net_context_impl_t::ibv_net_context_impl_t(runtime_t runtime_, attr_t attr_)
              "`-DLCI_NETWORK_BACKENDS=ofi`.\n");
 
   bool ret = ibv_detail::select_best_device_port(ib_dev_list, num_devices,
+                                                 attr.device_name.c_str(),
                                                  &ib_dev, &ib_dev_port);
   LCI_Assert(ret, "Cannot find available ibv device/port!\n");
 
@@ -92,20 +93,14 @@ ibv_net_context_impl_t::ibv_net_context_impl_t(runtime_t runtime_, attr_t attr_)
     LCI_Assert(ib_odp_mr, "Couldn't register MR for ODP\n");
   }
 
-  // query port attribute
-  uint8_t dev_port = 0;
-  for (; dev_port < 128; dev_port++) {
-    rc = ibv_query_port(ib_context, dev_port, &ib_port_attr);
-    if (rc == 0) {
-      break;
-    }
-  }
-  LCI_Assert(rc == 0, "Unable to query port\n");
+  // Query the selected active port.
+  rc = ibv_query_port(ib_context, ib_dev_port, &ib_port_attr);
+  LCI_Assert(rc == 0, "Unable to query port %u on device %s\n", ib_dev_port,
+             ibv_get_device_name(ib_dev));
   LCI_Assert(
       ib_port_attr.link_layer != IBV_LINK_LAYER_INFINIBAND || ib_port_attr.lid,
       "Couldn't get local LID\n");
 
-  ib_dev_port = dev_port;
   LCI_Log(LOG_INFO, "ibv", "Maximum MTU: %s; Active MTU: %s\n",
           mtu_str(ib_port_attr.max_mtu), mtu_str(ib_port_attr.active_mtu));
 

--- a/src/network/ibv/backend_ibv_detail.cpp
+++ b/src/network/ibv/backend_ibv_detail.cpp
@@ -53,21 +53,31 @@ static double translate_speed(uint8_t speed)
 }
 
 bool select_best_device_port(struct ibv_device** dev_list, int num_devices,
+                             const char* requested_device_name,
                              struct ibv_device** device_o, uint8_t* port_o)
 {
+  bool has_requested_device =
+      requested_device_name != nullptr && requested_device_name[0] != '\0';
+  bool requested_device_found = false;
   struct ibv_device* best_device = nullptr;
   uint8_t best_port = 0;
   double best_speed = 0;
 
   for (int i = 0; i < num_devices; ++i) {
     struct ibv_device* device = dev_list[i];
+    const char* device_name = ibv_get_device_name(device);
+
+    if (has_requested_device &&
+        strcmp(device_name, requested_device_name) != 0) {
+      continue;
+    }
+    requested_device_found = true;
 
     // open the device
     struct ibv_context* dev_ctx;
     dev_ctx = ibv_open_device(device);
     if (!dev_ctx) {
-      LCI_Log(LOG_INFO, "ibv", "Couldn't get context for %s.\n",
-              ibv_get_device_name(device));
+      LCI_Log(LOG_INFO, "ibv", "Couldn't get context for %s.\n", device_name);
       continue;
     }
 
@@ -75,8 +85,7 @@ bool select_best_device_port(struct ibv_device** dev_list, int num_devices,
     struct ibv_device_attr dev_attr;
     int ret = ibv_query_device(dev_ctx, &dev_attr);
     if (ret != 0) {
-      LCI_Log(LOG_INFO, "ibv", "Unable to query device %s.\n",
-              ibv_get_device_name(device));
+      LCI_Log(LOG_INFO, "ibv", "Unable to query device %s.\n", device_name);
       goto close_device;
     }
 
@@ -86,14 +95,14 @@ bool select_best_device_port(struct ibv_device** dev_list, int num_devices,
     for (uint8_t port_num = 1; port_num <= dev_attr.phys_port_cnt; port_num++) {
       ret = ibv_query_port(dev_ctx, port_num, &port_attr);
       if (ret != 0) {
-        LCI_Log(LOG_INFO, "ibv", "Unable to query port (%s:%d).\n",
-                ibv_get_device_name(device), port_num);
+        LCI_Log(LOG_INFO, "ibv", "Unable to query port (%s:%d).\n", device_name,
+                port_num);
         continue;
       }
       // Check whether the port is active
       if (port_attr.state != IBV_PORT_ACTIVE) {
         LCI_Log(LOG_INFO, "ibv", "%s:%d is not active (state: %d).\n",
-                ibv_get_device_name(device), port_num, port_attr.state);
+                device_name, port_num, port_attr.state);
         continue;
       }
       // Check whether we can get its lid
@@ -104,21 +113,19 @@ bool select_best_device_port(struct ibv_device** dev_list, int num_devices,
       // Calculate its speed
       int width = translate_width(port_attr.active_width);
       if (width <= 0) {
-        LCI_Log(LOG_INFO, "ibv", "%s:%d invalid width %d (%d).\n",
-                ibv_get_device_name(device), port_num, width,
-                port_attr.active_width);
+        LCI_Log(LOG_INFO, "ibv", "%s:%d invalid width %d (%d).\n", device_name,
+                port_num, width, port_attr.active_width);
         continue;
       }
       double speed = translate_speed(port_attr.active_speed);
       if (speed <= 0) {
-        LCI_Log(LOG_INFO, "ibv", "%s:%d invalid speed %f (%d).\n",
-                ibv_get_device_name(device), port_num, speed,
-                port_attr.active_width);
+        LCI_Log(LOG_INFO, "ibv", "%s:%d invalid speed %f (%d).\n", device_name,
+                port_num, speed, port_attr.active_width);
         continue;
       }
       double total_speed = speed * width;
-      LCI_Log(LOG_INFO, "ibv", "%s:%d speed is %.f (%d x %f).\n",
-              ibv_get_device_name(device), port_num, total_speed, width, speed);
+      LCI_Log(LOG_INFO, "ibv", "%s:%d speed is %.f (%d x %f).\n", device_name,
+              port_num, total_speed, width, speed);
       // Update the record if it is better.
       if (total_speed > best_speed) {
         best_speed = total_speed;
@@ -134,10 +141,22 @@ bool select_best_device_port(struct ibv_device** dev_list, int num_devices,
   if (best_speed > 0) {
     *device_o = best_device;
     *port_o = best_port;
-    LCI_Log(LOG_INFO, "ibv", "Select the best device %s:%d.\n",
+    LCI_Log(LOG_INFO, "ibv", "Select %s device %s:%d.\n",
+            has_requested_device ? "requested" : "best",
             ibv_get_device_name(best_device), best_port);
     return true;
   } else {
+    if (has_requested_device) {
+      if (!requested_device_found) {
+        LCI_Log(LOG_INFO, "ibv", "Requested device %s is not available.\n",
+                requested_device_name);
+      } else {
+        LCI_Log(LOG_INFO, "ibv",
+                "Requested device %s has no usable active port.\n",
+                requested_device_name);
+      }
+      return false;
+    }
     LCI_Log(LOG_INFO, "ibv", "No device is available!\n");
     return false;
   }

--- a/src/network/ibv/backend_ibv_detail.hpp
+++ b/src/network/ibv/backend_ibv_detail.hpp
@@ -11,6 +11,7 @@ namespace lci
 namespace ibv_detail
 {
 bool select_best_device_port(struct ibv_device** dev_list, int num_devices,
+                             const char* requested_device_name,
                              struct ibv_device** device_o, uint8_t* port_o);
 
 int select_best_gid_for_roce(struct ibv_device* ib_dev,

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -68,7 +68,7 @@ endpoint_impl_t::endpoint_impl_t(device_t device_, attr_t attr_)
 net_context_t alloc_net_context_x::call_impl(
     attr_backend_t backend, std::string ofi_provider_name, size_t max_msg_size,
     size_t max_inject_size, int ibv_gid_idx, bool ibv_force_gid_auto_select,
-    attr_ibv_odp_strategy_t ibv_odp_strategy,
+    std::string device_name, attr_ibv_odp_strategy_t ibv_odp_strategy,
     attr_ibv_prefetch_strategy_t ibv_prefetch_strategy, bool use_dmabuf,
     const char* name, void* user_context, runtime_t runtime) const
 {
@@ -79,6 +79,7 @@ net_context_t alloc_net_context_x::call_impl(
   attr.max_inject_size = max_inject_size;
   attr.ibv_gid_idx = ibv_gid_idx;
   attr.ibv_force_gid_auto_select = ibv_force_gid_auto_select;
+  attr.device_name = device_name;
   attr.ibv_odp_strategy = ibv_odp_strategy;
   attr.ibv_prefetch_strategy = ibv_prefetch_strategy;
   attr.use_dmabuf = use_dmabuf;

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -7,16 +7,50 @@ namespace lci
 {
 namespace
 {
-struct fi_info* search_for_prov(struct fi_info* ofi_info, const char* prov_name)
+char* dup_string_or_null(const std::string& value)
 {
-  struct fi_info* cur;
+  if (value.empty()) {
+    return nullptr;
+  }
+  char* ret = static_cast<char*>(malloc(value.size() + 1));
+  strcpy(ret, value.c_str());
+  return ret;
+}
 
-  for (cur = ofi_info; cur; cur = cur->next) {
-    if (strcmp(cur->fabric_attr->prov_name, prov_name) == 0) {
-      return cur;
+bool matches_device_name(struct fi_info* ofi_info,
+                         const std::string& requested_device_name)
+{
+  if (requested_device_name.empty()) {
+    return true;
+  }
+  return ofi_info->domain_attr != nullptr &&
+         ofi_info->domain_attr->name != nullptr &&
+         requested_device_name == ofi_info->domain_attr->name;
+}
+
+struct fi_info* select_info(struct fi_info* ofi_info,
+                            const std::string& requested_device_name)
+{
+  struct fi_info* first_match = nullptr;
+  struct fi_info* cxi_match = nullptr;
+
+  for (struct fi_info* cur = ofi_info; cur; cur = cur->next) {
+    if (!matches_device_name(cur, requested_device_name)) {
+      continue;
+    }
+    if (first_match == nullptr) {
+      first_match = cur;
+    }
+    if (strcmp(cur->fabric_attr->prov_name, "cxi") == 0) {
+      cxi_match = cur;
+      break;
     }
   }
-  return nullptr;
+
+  if (cxi_match != nullptr) {
+    return cxi_match;
+  }
+  return first_match;
 }
 }  // namespace
 
@@ -35,17 +69,12 @@ bool ofi_net_context_impl_t::check_availability()
 ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
     : net_context_impl_t(runtime_, attr_)
 {
-  const char* p = attr.ofi_provider_name.c_str();
-  char* prov_name_hint = nullptr;
-  if (p != nullptr && std::strlen(p) > 0) {
-    prov_name_hint = (char*)malloc(std::strlen(p) + 1);
-    // we don't need to explicitly free prov_name_hint later.
-    // fi_freeinfo(hints) will help us free it.
-    strcpy(prov_name_hint, p);
-  }
+  char* prov_name_hint = dup_string_or_null(attr.ofi_provider_name);
+  char* device_name_hint = dup_string_or_null(attr.device_name);
   struct fi_info* hints;
   hints = fi_allocinfo();
   hints->fabric_attr->prov_name = prov_name_hint;
+  hints->domain_attr->name = device_name_hint;
   hints->ep_attr->type = FI_EP_RDM;
   // not available on all clusters that we have access to.
   // hints->ep_attr->protocol = FI_PROTO_CXI_RNR;
@@ -66,8 +95,18 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
 
   // Create ofi_info.
   struct fi_info* all_infos;
-  FI_SAFECALL(
-      fi_getinfo(FI_VERSION(1, 6), nullptr, nullptr, 0, hints, &all_infos));
+  int ret =
+      fi_getinfo(FI_VERSION(1, 6), nullptr, nullptr, 0, hints, &all_infos);
+  if (ret) {
+    int err = ret < 0 ? -ret : ret;
+    if (!attr.device_name.empty()) {
+      LCI_Assert(false, "Cannot find OFI device/domain %s: %s\n",
+                 attr.device_name.c_str(), fi_strerror(err));
+    } else {
+      LCI_Assert(false, "err : %s (%s:%d)\n", fi_strerror(err), __FILE__,
+                 __LINE__);
+    }
+  }
   // Get libfabric version.
   uint32_t v = fi_version();
   int major = FI_MAJOR(v);
@@ -76,15 +115,17 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   // return the endpoints that are highest performing first.
   // But it appears cxi provider doesn't follow this rule,
   // so we have to do the search ourselves.
-  struct fi_info* cxi_info = search_for_prov(all_infos, "cxi");
-  if (cxi_info) {
-    // Found the cxi provider.
-    ofi_info = fi_dupinfo(cxi_info);
-  } else {
-    // Just use the first ofi_info.
-    ofi_info = fi_dupinfo(all_infos);
+  struct fi_info* selected_info = select_info(all_infos, attr.device_name);
+  if (selected_info == nullptr) {
+    LCI_Assert(false, "Cannot find OFI device/domain %s\n",
+               attr.device_name.c_str());
   }
+  ofi_info = fi_dupinfo(selected_info);
   fi_freeinfo(all_infos);
+  LCI_Log(LOG_STATUS, "ofi", "Domain name: %s\n",
+          ofi_info->domain_attr && ofi_info->domain_attr->name
+              ? ofi_info->domain_attr->name
+              : "(unknown)");
   LCI_Log(LOG_STATUS, "ofi", "Provider name: %s\n",
           ofi_info->fabric_attr->prov_name);
   LCI_Log(LOG_INFO, "ofi", "Protocol: %s\n",

--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -9,13 +9,11 @@ namespace lci
  * runtime: User wrappers
  *************************************************************/
 
-runtime_t alloc_runtime_x::call_impl(size_t packet_return_threshold,
-                                     int imm_nbits_tag, int imm_nbits_rcomp,
-                                     attr_rdv_protocol_t rdv_protocol,
-                                     bool alloc_default_device,
-                                     bool alloc_default_packet_pool,
-                                     bool alloc_default_matching_engine,
-                                     const char* name, void* user_context) const
+runtime_t alloc_runtime_x::call_impl(
+    size_t packet_return_threshold, int imm_nbits_tag, int imm_nbits_rcomp,
+    attr_rdv_protocol_t rdv_protocol, bool alloc_default_device,
+    bool alloc_default_packet_pool, bool alloc_default_matching_engine,
+    const char* name, void* user_context, std::string device_name) const
 {
   runtime_attr_t attr;
   attr.packet_return_threshold = packet_return_threshold;
@@ -31,6 +29,7 @@ runtime_t alloc_runtime_x::call_impl(size_t packet_return_threshold,
              "imm_nbits_tag + imm_nbits_rcomp should be less than 31!\n");
   runtime_t runtime;
   runtime.p_impl = new runtime_impl_t(attr);
+  runtime.get_impl()->default_net_context_device_name = device_name;
   runtime.get_impl()->initialize();
   return runtime;
 }
@@ -45,7 +44,7 @@ runtime_t g_runtime_init_x::call_impl(
     size_t packet_return_threshold, int imm_nbits_tag, int imm_nbits_rcomp,
     attr_rdv_protocol_t rdv_protocol, bool alloc_default_device,
     bool alloc_default_packet_pool, bool alloc_default_matching_engine,
-    const char* name, void* user_context) const
+    const char* name, void* user_context, std::string device_name) const
 {
   runtime_attr_t attr;
   attr.packet_return_threshold = packet_return_threshold;
@@ -66,6 +65,7 @@ runtime_t g_runtime_init_x::call_impl(
   LCI_Assert(attr.imm_nbits_tag + attr.imm_nbits_rcomp <= 31,
              "imm_nbits_tag + imm_nbits_rcomp should be less than 31!\n");
   g_default_runtime.p_impl = new runtime_impl_t(attr);
+  g_default_runtime.get_impl()->default_net_context_device_name = device_name;
   g_default_runtime.get_impl()->initialize();
   return g_default_runtime;
 }
@@ -95,7 +95,8 @@ void runtime_impl_t::initialize()
   // the matching engine key format.
   attr.max_tag = std::numeric_limits<uint32_t>::max();
   attr.max_rcomp = std::numeric_limits<rcomp_t>::max();
-  default_net_context = alloc_net_context_x().runtime(runtime)();
+  default_net_context = alloc_net_context_x().runtime(runtime).device_name(
+      default_net_context_device_name)();
   if (attr.rdv_protocol == attr_rdv_protocol_t::auto_select) {
     bool support_putimm = true;
     if (!default_net_context.is_empty()) {

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -18,6 +18,7 @@ class runtime_impl_t
 
   runtime_t runtime;
   runtime_t::attr_t attr;
+  std::string default_net_context_device_name;
   net_context_t default_net_context;
   device_t default_device;
   packet_pool_t default_packet_pool;


### PR DESCRIPTION
Allow users to explicitly select a HCA on a per-net-context basis.

Every runtime has a default net context.
```
auto runtime = lci::alloc_runtime_x().device_name("mlx5_1")();
```
or
```
auto net_context = lci::alloc_net_context_x().device_name("mlx5_1")();
auto device = lci::alloc_device_x().net_context(net_context)();
```