### PR TITLE
libfabric before v2.5 does not support rocr as device option

### DIFF
--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -365,7 +365,13 @@ mr_t ofi_device_impl_t::register_memory_impl(void* buffer, size_t size)
     mr_attr.device.cuda = ret.get_impl()->acc_attr.device;
 #elif defined(LCI_USE_HIP)
     mr_attr.iface = FI_HMEM_ROCR;
+#if defined(FI_MAJOR_VERSION) && defined(FI_MINOR_VERSION) && \
+    (FI_MAJOR_VERSION > 2 || (FI_MAJOR_VERSION == 2 && FI_MINOR_VERSION >= 5))
     mr_attr.device.rocr = ret.get_impl()->acc_attr.device;
+#else
+    // Older libfabric headers do not expose the ROCR-specific union member.
+    mr_attr.device.reserved = ret.get_impl()->acc_attr.device;
+#endif
 #endif
   }
 #endif  // LCI_USE_CUDA || LCI_USE_HIP


### PR DESCRIPTION
According to the libfabric release https://github.com/ofiwg/libfabric/blob/main/NEWS.md "rocr" is not supported as an option for fi_mr_attr.device until libfabric v2.5.0. This will cause the HIP-enabled lci build to fail if the libfabric version is lower. This fix checks the version of libfabric and selects between "rocr" (2.5+) and "reserved" (before 2.5).