### PR TITLE
refactor HIP/ROCR cmake package discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if(NOT LCI_WITH_LCT_ONLY)
     target_compile_options(
       LCI
       PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-unused-private-field>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:CrayClang>>:-Wno-unused-private-field>
     )
   endif()
 
@@ -383,9 +383,6 @@ if(NOT LCI_WITH_LCT_ONLY)
           STRING
           "Comma (or semicolon) separated list of HIP architectures to build for (e.g. gfx90a,gfx942)"
           FORCE)
-
-    # Link against HIP runtime
-    target_link_libraries(LCI PRIVATE hip::host)
 
     set_target_hip_standard(LCI STANDARD ${LCI_HIP_STANDARD})
     set_target_hip_architectures(LCI ARCHITECTURES ${LCI_HIP_ARCH})

--- a/cmake_modules/HipHelpers.cmake
+++ b/cmake_modules/HipHelpers.cmake
@@ -3,33 +3,11 @@
 
 include_guard(GLOBAL)
 
-function(populate_rocm_root_hints ROCM_ROOT_HINTS)
-  set(rocm_root_hints)
-
-  if(CMAKE_HIP_COMPILER_ROCM_ROOT)
-    list(APPEND rocm_root_hints ${CMAKE_HIP_COMPILER_ROCM_ROOT})
-  endif()
-  if(DEFINED ENV{ROCM_PATH})
-    list(APPEND rocm_root_hints $ENV{ROCM_PATH})
-  endif()
-  if(DEFINED ENV{ROCM_ROOT})
-    list(APPEND rocm_root_hints $ENV{ROCM_ROOT})
-  endif()
-  list(APPEND rocm_root_hints /opt/rocm)
-  list(REMOVE_DUPLICATES rocm_root_hints)
-
-  set(${ROCM_ROOT_HINTS}
-      ${rocm_root_hints}
-      PARENT_SCOPE)
-endfunction(populate_rocm_root_hints)
-
 # Enable the HIP language and find the HIP/ROCm toolkit.
 macro(enable_hip_language_and_find_hip)
 
   # Enable the HIP language
   enable_language(HIP)
-
-  populate_rocm_root_hints(LCI_ROCM_ROOT_HINTS)
 
   # Find the HIP/ROCm toolkit.
   find_package(
@@ -37,7 +15,10 @@ macro(enable_hip_language_and_find_hip)
     CONFIG
     REQUIRED
     HINTS
-    ${LCI_ROCM_ROOT_HINTS}
+    ${CMAKE_HIP_COMPILER_ROCM_ROOT}
+    $ENV{ROCM_PATH}
+    $ENV{ROCM_ROOT}
+    /opt/rocm
     PATH_SUFFIXES
     lib/cmake/hip
     lib64/cmake/hip)
@@ -48,7 +29,10 @@ macro(enable_hip_language_and_find_hip)
     CONFIG
     REQUIRED
     HINTS
-    ${LCI_ROCM_ROOT_HINTS}
+    ${CMAKE_HIP_COMPILER_ROCM_ROOT}
+    $ENV{ROCM_PATH}
+    $ENV{ROCM_ROOT}
+    /opt/rocm
     PATH_SUFFIXES
     lib/cmake/hsa-runtime64
     lib64/cmake/hsa-runtime64)

--- a/cmake_modules/HipHelpers.cmake
+++ b/cmake_modules/HipHelpers.cmake
@@ -3,14 +3,55 @@
 
 include_guard(GLOBAL)
 
+function(populate_rocm_root_hints ROCM_ROOT_HINTS)
+  set(rocm_root_hints)
+
+  if(CMAKE_HIP_COMPILER_ROCM_ROOT)
+    list(APPEND rocm_root_hints ${CMAKE_HIP_COMPILER_ROCM_ROOT})
+  endif()
+  if(DEFINED ENV{ROCM_PATH})
+    list(APPEND rocm_root_hints $ENV{ROCM_PATH})
+  endif()
+  if(DEFINED ENV{ROCM_ROOT})
+    list(APPEND rocm_root_hints $ENV{ROCM_ROOT})
+  endif()
+  list(APPEND rocm_root_hints /opt/rocm)
+  list(REMOVE_DUPLICATES rocm_root_hints)
+
+  set(${ROCM_ROOT_HINTS}
+      ${rocm_root_hints}
+      PARENT_SCOPE)
+endfunction(populate_rocm_root_hints)
+
 # Enable the HIP language and find the HIP/ROCm toolkit.
 macro(enable_hip_language_and_find_hip)
 
   # Enable the HIP language
   enable_language(HIP)
 
-  # Find the HIP/ROCm toolkit
-  find_package(hip REQUIRED)
+  populate_rocm_root_hints(LCI_ROCM_ROOT_HINTS)
+
+  # Find the HIP/ROCm toolkit.
+  find_package(
+    hip
+    CONFIG
+    REQUIRED
+    HINTS
+    ${LCI_ROCM_ROOT_HINTS}
+    PATH_SUFFIXES
+    lib/cmake/hip
+    lib64/cmake/hip)
+
+  # accelerator_hip.cpp also uses the ROCR/HSA runtime directly.
+  find_package(
+    hsa-runtime64
+    CONFIG
+    REQUIRED
+    HINTS
+    ${LCI_ROCM_ROOT_HINTS}
+    PATH_SUFFIXES
+    lib/cmake/hsa-runtime64
+    lib64/cmake/hsa-runtime64)
 
 endmacro(enable_hip_language_and_find_hip)
 

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -7,4 +7,14 @@ endif()
 
 if(LCI_USE_HIP)
   target_sources_relative(LCI PRIVATE accelerator_hip.cpp)
+  target_link_libraries(LCI PRIVATE hip::host hsa-runtime64::hsa-runtime64)
+
+  # ROCm HIP headers rely on anonymous struct/union extensions that trigger
+  # pedantic warnings with clang-family compilers.
+  target_compile_options(
+    LCI
+    PRIVATE
+      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:CrayClang>>>:-Wno-gnu-anonymous-struct>
+      $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:CrayClang>>>:-Wno-nested-anon-types>
+  )
 endif()


### PR DESCRIPTION
Alternative to #161.

This keeps the HIP/HSA build fix while avoiding top-level CMake clutter and replacing manual library lookup with package-target discovery.

Key changes:
- discover HIP and hsa-runtime64 via `find_package(... CONFIG)` with ROCm-aware hint paths
- link `hip::host` and `hsa-runtime64::hsa-runtime64` from `src/accelerator/CMakeLists.txt`
- keep the generic CrayClang unused-private-field suppression in the top-level file

Validation:
- `cmake` configure with `LCI_USE_HIP=ON`
- `cmake --build --target LCI` with HIP enabled
