### PR TITLE
OFI: add MR and all lock modes

### DIFF
--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -74,7 +74,10 @@ enum attr_net_lock_mode_t {
   LCI_NET_TRYLOCK_SEND = 1,
   LCI_NET_TRYLOCK_RECV = 1 << 1,
   LCI_NET_TRYLOCK_POLL = 1 << 2,
-  LCI_NET_TRYLOCK_MAX = 1 << 3,
+  LCI_NET_LOCK_MR = 1 << 3,
+  LCI_NET_LOCK_ALL = LCI_NET_TRYLOCK_SEND | LCI_NET_TRYLOCK_RECV |
+                     LCI_NET_TRYLOCK_POLL | LCI_NET_LOCK_MR,
+  LCI_NET_TRYLOCK_MAX = 1 << 4,
 };
 
 // mimic std::optional as we don't want to force c++17 for now

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -110,6 +110,8 @@ void global_config_initialize()
           {"send", LCI_NET_TRYLOCK_SEND},
           {"recv", LCI_NET_TRYLOCK_RECV},
           {"poll", LCI_NET_TRYLOCK_POLL},
+          {"mr", LCI_NET_LOCK_MR},
+          {"all", LCI_NET_LOCK_ALL},
       };
       g_default_attr.ofi_lock_mode =
           LCT_parse_arg(dict, sizeof(dict) / sizeof(dict[0]), p, ",");

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -377,15 +377,18 @@ mr_t ofi_device_impl_t::register_memory_impl(void* buffer, size_t size)
 #endif  // LCI_USE_CUDA || LCI_USE_HIP
 
   struct fid_mr* ofi_mr;
-  FI_SAFECALL(fi_mr_regattr(ofi_domain, &mr_attr, 0, &ofi_mr));
+  {
+    ofi_lock_guard_t lock_guard(ofi_lock_mode, LCI_NET_LOCK_MR, lock);
+    FI_SAFECALL(fi_mr_regattr(ofi_domain, &mr_attr, 0, &ofi_mr));
 
-  // FI_SAFECALL(fi_mr_reg(
-  //     ofi_domain, buffer, size,
-  //     FI_SEND | FI_RECV | FI_READ | FI_WRITE | FI_REMOTE_WRITE |
-  //     FI_REMOTE_READ, 0, rdma_key, 0, &ofi_mr, 0));
-  if (ofi_domain_attr->mr_mode & FI_MR_ENDPOINT) {
-    FI_SAFECALL(fi_mr_bind(ofi_mr, &ofi_ep->fid, 0));
-    FI_SAFECALL(fi_mr_enable(ofi_mr));
+    // FI_SAFECALL(fi_mr_reg(
+    //     ofi_domain, buffer, size,
+    //     FI_SEND | FI_RECV | FI_READ | FI_WRITE | FI_REMOTE_WRITE |
+    //     FI_REMOTE_READ, 0, rdma_key, 0, &ofi_mr, 0));
+    if (ofi_domain_attr->mr_mode & FI_MR_ENDPOINT) {
+      FI_SAFECALL(fi_mr_bind(ofi_mr, &ofi_ep->fid, 0));
+      FI_SAFECALL(fi_mr_enable(ofi_mr));
+    }
   }
   static_cast<ofi_mr_impl_t*>(ret.p_impl)->ofi_mr = ofi_mr;
   return ret;
@@ -394,7 +397,10 @@ mr_t ofi_device_impl_t::register_memory_impl(void* buffer, size_t size)
 void ofi_device_impl_t::deregister_memory_impl(mr_impl_t* mr_impl)
 {
   auto p_ofi_mr = static_cast<ofi_mr_impl_t*>(mr_impl);
-  FI_SAFECALL(fi_close(&p_ofi_mr->ofi_mr->fid));
+  {
+    ofi_lock_guard_t lock_guard(ofi_lock_mode, LCI_NET_LOCK_MR, lock);
+    FI_SAFECALL(fi_close(&p_ofi_mr->ofi_mr->fid));
+  }
   delete p_ofi_mr;
 }
 

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -41,6 +41,32 @@
 
 namespace lci
 {
+class ofi_lock_guard_t
+{
+ public:
+  ofi_lock_guard_t(uint64_t lock_mode, uint64_t mode, spinlock_t& spinlock)
+      : should_lock((lock_mode & mode) != 0), spinlock(spinlock)
+  {
+    if (should_lock) {
+      spinlock.lock();
+    }
+  }
+
+  ~ofi_lock_guard_t()
+  {
+    if (should_lock) {
+      spinlock.unlock();
+    }
+  }
+
+  ofi_lock_guard_t(const ofi_lock_guard_t&) = delete;
+  ofi_lock_guard_t& operator=(const ofi_lock_guard_t&) = delete;
+
+ private:
+  bool should_lock;
+  spinlock_t& spinlock;
+};
+
 class ofi_net_context_impl_t : public lci::net_context_impl_t
 {
  public:


### PR DESCRIPTION
## Summary
- Add an `mr` OFI lock mode bit for memory registration and deregistration calls.
- Add an `all` alias that enables send, recv, poll, and mr locking.
- Guard `fi_mr_regattr`, `fi_mr_bind`, `fi_mr_enable`, and MR `fi_close` with the existing per-device OFI lock using blocking acquisition for MR operations.

Fixes #164

## Validation
- `git show --check --format=short HEAD` succeeded.
- `cmake -S . -B build-default -DLCI_WITH_TESTS=OFF -DLCI_WITH_EXAMPLES=OFF -DLCI_WITH_BENCHMARKS=OFF -DLCI_WITH_DOC=OFF -DLCI_WITH_TOOLS=OFF -DLCI_BUILD_WARN_AS_ERROR=OFF && cmake --build build-default -j2` succeeded with the available IBV backend.
- OFI-specific configure/build could not be run on this host: `cmake -S . -B build-quickfix -DLCI_NETWORK_BACKENDS=ofi ...` failed because libfabric/OFI headers and libraries were not installed (`Could NOT find OFI`).
