### PR TITLE
Fix put benchmark MR/RMR device matching

### DIFF
--- a/benchmarks/pt2pt/bench_put_bw.cpp
+++ b/benchmarks/pt2pt/bench_put_bw.cpp
@@ -17,7 +17,8 @@ struct config_t {
   size_t niters = 10;
 } g_config;
 
-void worker(int peer_rank, lci::device_t device, int *data, lci::rmr_t rmr, lci::comp_t comp, lci::rcomp_t rcomp)
+void worker(int peer_rank, lci::device_t device, int *data, lci::mr_t mr,
+            lci::rmr_t rmr, lci::comp_t comp, lci::rcomp_t rcomp)
 {
   int thread_id = omp_get_thread_num();
   int nthreads = omp_get_num_threads();
@@ -28,7 +29,11 @@ void worker(int peer_rank, lci::device_t device, int *data, lci::rmr_t rmr, lci:
     for (size_t j = thread_id; j < g_config.nelems; j += nthreads) {
       lci::status_t status;
       do {
-        status = lci::post_put_x(peer_rank, data + j, sizeof(int), comp, j * sizeof(int), rmr).device(device).allow_done(false)();
+        status = lci::post_put_x(peer_rank, data + j, sizeof(int), comp,
+                                 j * sizeof(int), rmr)
+                     .device(device)
+                     .mr(mr)
+                     .allow_done(false)();
         lci::progress_x().device(device)();
       } while (status.is_retry());
     }
@@ -114,19 +119,18 @@ int main(int argc, char** argv)
       ((int*)data)[i] = 0;
     }
   }
-  std::vector<lci::mr_t> mrs;
-  std::vector<lci::rmr_t> rmrs;
-  std::vector<lci::rmr_t> all_rmrs;
+  std::vector<lci::mr_t> mrs(g_config.ndevices);
+  std::vector<lci::rmr_t> peer_rmrs(g_config.ndevices);
+  std::vector<lci::rmr_t> all_rmrs(nranks);
   for (int i = 0; i < g_config.ndevices; i++) {
-    lci::mr_t mr = lci::register_memory_x(data, size).device(devices[i])();
-    mrs.push_back(mr);
-    lci::rmr_t rmr = lci::get_rmr(mr);
-    rmrs.push_back(rmr);
+    // Some network endpoints have device-specific MR/RMR keys; keep the
+    // registered local MR and exchanged peer RMR matched to each LCI device.
+    mrs[i] = lci::register_memory_x(data, size).device(devices[i])();
+    lci::rmr_t rmr = lci::get_rmr(mrs[i]);
+    lci::allgather_x(&rmr, all_rmrs.data(), sizeof(lci::rmr_t))
+        .device(devices[i])();
+    peer_rmrs[i] = all_rmrs[peer_rank];
   }
-  all_rmrs.resize(nranks * g_config.ndevices);
-  lci::allgather_x(rmrs.data(), all_rmrs.data(), sizeof(lci::rmr_t) * g_config.ndevices).device(devices[0])();
-  std::vector<lci::rmr_t> peer_rmrs(all_rmrs.begin() + peer_rank * g_config.ndevices,
-                                    all_rmrs.begin() + (peer_rank + 1) * g_config.ndevices);
   // allocate completion counter
   lci::comp_t comp = lci::alloc_counter();
   lci::rcomp_t rcomp = lci::register_rcomp(comp);
@@ -138,7 +142,8 @@ int main(int argc, char** argv)
     {
       int device_idx = omp_get_thread_num() % g_config.ndevices;
       lci::device_t device = devices[device_idx];
-      worker(peer_rank, device, (int*)data, peer_rmrs[device_idx], comp, rcomp);
+      worker(peer_rank, device, (int*)data, mrs[device_idx],
+             peer_rmrs[device_idx], comp, rcomp);
       lci::wait_drained_x().device(device)();
     }
   }


### PR DESCRIPTION
## Summary
- Patch the raw LCI put-rate benchmark (`benchmarks/pt2pt/bench_put_bw.cpp`, executable `lci_bench_put_bw`) to keep MR/RMR setup matched to each allocated LCI device.
- Register the benchmark buffer once per device after device allocation.
- Exchange each device's RMR with `allgather_x(...).device(devices[i])()` and pass the matching `(device, mr, peer_rmr)` tuple to sender threads.

Fixes #166

## Validation
- `git diff --check`
- Local build: `cmake --build /tmp/lci-issue166-build --target bench_put_bw -j 8`
- Local smoke attempted: `timeout 30 /tmp/lci-issue166-build/bin/lci_bench_put_bw -t 1 -d 1 --nelems 16 --niters 1` (blocked by local runtime environment: no available network backend)
- Lockhart/CXI build: `cmake --build build-issue166 --target bench_put_bw -j 8`
- Lockhart/CXI smoke: `timeout 90 srun --mpi=pmix -N 2 -n 2 --ntasks-per-node=1 --time=00:02:00 build-issue166/bin/lci_bench_put_bw -t 1 -d 1 --nelems 1024 --niters 1`
- Lockhart/CXI smoke: `timeout 90 srun --mpi=pmix -N 2 -n 2 --ntasks-per-node=1 --time=00:02:00 build-issue166/bin/lci_bench_put_bw -t 2 -d 2 --nelems 1024 --niters 1`
