### PR TITLE
Preserve user RMR base for cached registrations

### DIFF
--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -335,9 +335,10 @@ inline bool mr_t::is_empty() const
  */
 struct rmr_t {
   uintptr_t base;
+  uintptr_t mr_base;
   uint64_t opaque_rkey;
-  rmr_t() : base(0), opaque_rkey(0) {}
-  bool is_empty() const { return base == 0 && opaque_rkey == 0; }
+  rmr_t() : base(0), mr_base(0), opaque_rkey(0) {}
+  bool is_empty() const { return base == 0 && mr_base == 0 && opaque_rkey == 0; }
 };
 
 /**

--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -338,7 +338,10 @@ struct rmr_t {
   uintptr_t mr_base;
   uint64_t opaque_rkey;
   rmr_t() : base(0), mr_base(0), opaque_rkey(0) {}
-  bool is_empty() const { return base == 0 && mr_base == 0 && opaque_rkey == 0; }
+  bool is_empty() const
+  {
+    return base == 0 && mr_base == 0 && opaque_rkey == 0;
+  }
 };
 
 /**

--- a/src/network/device_inline.hpp
+++ b/src/network/device_inline.hpp
@@ -70,6 +70,7 @@ inline mr_t device_impl_t::register_memory(void* address, size_t size)
     mr.p_impl->device = device;
     mr.p_impl->address = address;
     mr.p_impl->size = size;
+    mr.p_impl->mr_base = address;
   }
   LCI_DBG_Log(LOG_TRACE, "network",
               "register_memory address %p size %lu return %p\n", address, size,

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -91,6 +91,10 @@ class mr_impl_t
   device_t device;
   void* address;
   size_t size;
+  // Provider/cached memory registrations may cover a larger containing
+  // region than the user-requested range. address/size track the user range;
+  // mr_base tracks the base address used by the provider registration.
+  void* mr_base;
 #if defined(LCI_USE_CUDA) || defined(LCI_USE_HIP)
   accelerator::buffer_attr_t acc_attr;
   int dmabuf_fd;

--- a/src/network/network_inline.hpp
+++ b/src/network/network_inline.hpp
@@ -15,6 +15,7 @@ inline rmr_t mr_impl_t::get_rmr()
 {
   rmr_t ret;
   ret.base = reinterpret_cast<uintptr_t>(address);
+  ret.mr_base = reinterpret_cast<uintptr_t>(mr_base);
   ret.opaque_rkey = device.get_impl()->get_rkey(this);
   return ret;
 }

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -74,6 +74,15 @@ inline void* get_mr_desc(mr_t mr)
 {
   return fi_mr_desc(static_cast<ofi_mr_impl_t*>(mr.p_impl)->ofi_mr);
 }
+
+inline uintptr_t get_remote_addr(rmr_t rmr, uint64_t offset, uint64_t mr_mode)
+{
+  if (mr_mode & FI_MR_VIRT_ADDR) {
+    return rmr.base + offset;
+  } else {
+    return (rmr.base - rmr.mr_base) + offset;
+  }
+}
 }  // namespace ofi_detail
 
 inline error_t ofi_device_impl_t::post_recv_impl(void* buffer, size_t size,
@@ -178,12 +187,8 @@ inline error_t ofi_endpoint_impl_t::post_puts_impl(int rank, void* buffer,
                                                    void* user_context,
                                                    bool /*high_priority*/)
 {
-  uintptr_t addr;
-  if (ofi_domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
-    addr = rmr.base + offset;
-  } else {
-    addr = offset;
-  }
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;
@@ -219,12 +224,8 @@ inline error_t ofi_endpoint_impl_t::post_put_impl(int rank, void* buffer,
                                                   void* user_context,
                                                   bool /*high_priority*/)
 {
-  uintptr_t addr;
-  if (ofi_domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
-    addr = rmr.base + offset;
-  } else {
-    addr = offset;
-  }
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;
@@ -258,12 +259,8 @@ inline error_t ofi_endpoint_impl_t::post_putImms_impl(
     int rank, void* buffer, size_t size, uint64_t offset, rmr_t rmr,
     net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
 {
-  uintptr_t addr;
-  if (ofi_domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
-    addr = rmr.base + offset;
-  } else {
-    addr = offset;
-  }
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;
@@ -300,12 +297,8 @@ inline error_t ofi_endpoint_impl_t::post_putImm_impl(
     int rank, void* buffer, size_t size, mr_t mr, uint64_t offset, rmr_t rmr,
     net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
 {
-  uintptr_t addr;
-  if (ofi_domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
-    addr = rmr.base + offset;
-  } else {
-    addr = offset;
-  }
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;
@@ -345,12 +338,8 @@ inline error_t ofi_endpoint_impl_t::post_get_impl(int rank, void* buffer,
                                                   void* user_context,
                                                   bool /*high_priority*/)
 {
-  uintptr_t addr;
-  if (ofi_domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
-    addr = rmr.base + offset;
-  } else {
-    addr = offset;
-  }
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;

--- a/src/reg_cache/reg_cache.cpp
+++ b/src/reg_cache/reg_cache.cpp
@@ -62,9 +62,15 @@ class RegCache::impl
     auto* entry = reinterpret_cast<rcache_entry_generic_t*>(region);
     mr.p_impl = entry->mr;
     mr.p_impl->rcache_region = region;
+    // Preserve the user-requested registration range separately from the
+    // provider/cached registration range. UCX rcache may return a containing
+    // region whose provider MR starts before address.
+    mr.p_impl->address = address;
+    mr.p_impl->size = size;
+    mr.p_impl->mr_base = reinterpret_cast<void*>(region->super.start);
     LCI_Log(LOG_TRACE, "reg_cache",
-            "RegCache::get address %p size %lu => mr %p\n", address, size,
-            mr.p_impl);
+            "RegCache::get address %p size %lu provider_base %p => mr %p\n",
+            address, size, mr.p_impl->mr_base, mr.p_impl);
     return mr;
   }
 
@@ -158,6 +164,7 @@ ucs_status_t RegCache::impl::mem_reg_cb(void* context, ucs_rcache_t* /*rcache*/,
   entry->mr->device = dev->device;
   entry->mr->address = reinterpret_cast<void*>(start);
   entry->mr->size = len;
+  entry->mr->mr_base = reinterpret_cast<void*>(start);
   LCI_Log(LOG_TRACE, "reg_cache",
           "RegCache::mem_reg_cb address %p size %lu => mr %p\n",
           reinterpret_cast<void*>(start), len, entry->mr);

--- a/tests/unit/loopback/all.cpp
+++ b/tests/unit/loopback/all.cpp
@@ -27,6 +27,7 @@
 #include "test_get.hpp"
 #include "test_matching_policy.hpp"
 #include "test_rdv_protocol.hpp"
+#include "test_reg_cache.hpp"
 
 int main(int argc, char** argv)
 {

--- a/tests/unit/loopback/test_reg_cache.hpp
+++ b/tests/unit/loopback/test_reg_cache.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 The LCI Project Authors
+// SPDX-License-Identifier: NCSA
+
+#include <cstdlib>
+#include <unistd.h>
+
+#if LCI_USE_REG_CACHE
+
+TEST(RegCache, rmr_preserves_user_base_for_subrange)
+{
+  lci::g_runtime_init();
+
+  const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  ASSERT_GT(page_size, 0u);
+
+  void* allocation = nullptr;
+  ASSERT_EQ(posix_memalign(&allocation, page_size, page_size * 4), 0);
+  ASSERT_NE(allocation, nullptr);
+
+  char* user_base = static_cast<char*>(allocation) + 848;
+  constexpr size_t user_size = 8117;
+
+  lci::mr_t mr = lci::register_memory(user_base, user_size);
+  lci::rmr_t rmr = lci::get_rmr(mr);
+
+  EXPECT_EQ(rmr.base, reinterpret_cast<uintptr_t>(user_base));
+  EXPECT_LE(rmr.mr_base, rmr.base);
+
+  lci::deregister_memory(&mr);
+  free(allocation);
+  lci::g_runtime_fina();
+}
+
+#endif  // LCI_USE_REG_CACHE


### PR DESCRIPTION
## Summary
- preserve the user-requested registration base separately from the provider/cached MR base
- export both bases in `rmr_t` and use the provider-base-relative offset for OFI non-virtual-address providers
- add a RegCache loopback unit test for subrange registrations

Fixes #168

## Testing
- `cmake -S . -B build-agent -DLCI_WITH_TESTS=ON -DLCI_USE_REG_CACHE=ON -DLCI_BUILD_WARN_AS_ERROR=OFF`
- `cmake --build build-agent --target test-loopback-all -j 8`
- `cmake -S . -B build-agent-noreg -DLCI_WITH_TESTS=ON -DLCI_BUILD_WARN_AS_ERROR=OFF && cmake --build build-agent-noreg --target test-loopback-all -j 8`
- `ctest --test-dir build-agent -R loopback.*all --output-on-failure` *(fails locally before executing the new scenario because this host has no available network device/backend at runtime: `No available network backend found`)*
