### PR TITLE
Add nonblocking alltoall support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
               -DLCI_NETWORK_BACKENDS=ofi,ibv
               -DLCI_USE_TCMALLOC=OFF
               -DLCI_USE_REG_CACHE=${{ matrix.reg_cache }}
+              -DLCI_BACKEND_MAX_CQES_DEFAULT=32768
               -DCMAKE_VERBOSE_MAKEFILE=ON
             "
 

--- a/src/binding/input/collective.py
+++ b/src/binding/input/collective.py
@@ -129,11 +129,12 @@ operation(
         optional_arg("device_t", "device", "runtime.get_impl()->default_device", comment="The device to use."),
         optional_arg("endpoint_t", "endpoint", "device.get_impl()->default_endpoint", comment="The endpoint to use."),
         optional_arg("matching_engine_t", "matching_engine", "runtime.get_impl()->default_coll_matching_engine", comment="The matching engine to use."),
+        optional_arg("comp_t", "comp", "COMP_NULL", comment="The completion to signal when the operation completes."),
         optional_arg("comp_semantic_t", "comp_semantic", "comp_semantic_t::memory", comment="The completion semantic."),
     ],
     doc = {
         "in_group": "LCI_COLL",
-        "brief": "A blocking alltoall operation.",
+        "brief": "An alltoall operation.",
     }
 ),
 ]

--- a/src/collective/alltoall.cpp
+++ b/src/collective/alltoall.cpp
@@ -9,7 +9,7 @@ void alltoall_x::call_impl(const void* sendbuf, void* recvbuf, size_t size,
                            runtime_t runtime, device_t device,
                            endpoint_t endpoint,
                            matching_engine_t matching_engine,
-                           comp_semantic_t comp_semantic) const
+                           comp_t comp, comp_semantic_t comp_semantic) const
 {
   int seqnum = get_sequence_number();
 
@@ -19,45 +19,68 @@ void alltoall_x::call_impl(const void* sendbuf, void* recvbuf, size_t size,
               "enter alltoall %d (sendbuf %p recvbuf %p size %lu)\n", seqnum,
               sendbuf, recvbuf, size);
 
-  comp_t comp = alloc_sync_x().threshold(2 * nranks - 2).runtime(runtime)();
+  void* self_recvbuf = static_cast<char*>(recvbuf) + rank * size;
+  void* self_sendbuf =
+      static_cast<char*>(const_cast<void*>(sendbuf)) + rank * size;
+  memcpy(self_recvbuf, self_sendbuf, size);
+
+  if (nranks == 1) {
+    if (!comp.is_empty()) {
+      lci::comp_signal(comp, status_t(errorcode_t::done));
+    }
+    LCI_DBG_Log(LOG_TRACE, "collective",
+                "leave alltoall %d (sendbuf %p recvbuf %p size %lu)\n",
+                seqnum, sendbuf, recvbuf, size);
+    return;
+  }
+
+  comp_t graph = alloc_graph_x().runtime(runtime).comp(comp)();
 
   for (int i = 0; i < nranks; ++i) {
+    if (i == rank) {
+      continue;
+    }
     void* current_recvbuf =
         static_cast<void*>(static_cast<char*>(recvbuf) + i * size);
     void* current_sendbuf = static_cast<void*>(
         static_cast<char*>(const_cast<void*>(sendbuf)) + i * size);
-    if (i == rank) {
-      memcpy(current_recvbuf, current_sendbuf, size);
-      continue;
-    }
-    status_t status;
-    do {
-      status = post_recv_x(i, current_recvbuf, size, seqnum, comp)
+
+    auto recv_node = graph_add_node_op(
+        graph, post_recv_x(i, current_recvbuf, size, seqnum, graph)
                    .runtime(runtime)
                    .device(device)
                    .endpoint(endpoint)
                    .matching_engine(matching_engine)
                    .comp_semantic(comp_semantic)
-                   .allow_done(false)();
-      progress_x().runtime(runtime).device(device).endpoint(endpoint)();
-    } while (status.is_retry());
-    do {
-      status = post_send_x(i, current_sendbuf, size, seqnum, comp)
+                   .allow_retry(false));
+    auto send_node = graph_add_node_op(
+        graph, post_send_x(i, current_sendbuf, size, seqnum, graph)
                    .runtime(runtime)
                    .device(device)
                    .endpoint(endpoint)
                    .matching_engine(matching_engine)
                    .comp_semantic(comp_semantic)
-                   .allow_done(false)();
-      progress_x().runtime(runtime).device(device).endpoint(endpoint)();
-    } while (status.is_retry());
+                   .allow_retry(false));
+    graph_add_edge(graph, GRAPH_START, recv_node);
+    graph_add_edge(graph, GRAPH_START, send_node);
+    graph_add_edge(graph, recv_node, GRAPH_END);
+    graph_add_edge(graph, send_node, GRAPH_END);
   }
 
-  // sync_wait_x(comp, nullptr).runtime(runtime)();
-  while (!sync_test_x(comp, nullptr).runtime(runtime)()) {
-    progress_x().runtime(runtime).device(device).endpoint(endpoint)();
+  graph_start(graph);
+  if (comp.is_empty()) {
+    // blocking wait
+    status_t status;
+    do {
+      progress_x().runtime(runtime).device(device).endpoint(endpoint)();
+      status = graph_test(graph);
+    } while (status.is_retry());
+    free_comp(&graph);
   }
-  free_comp(&comp);
+
+  LCI_DBG_Log(LOG_TRACE, "collective",
+              "leave alltoall %d (sendbuf %p recvbuf %p size %lu)\n", seqnum,
+              sendbuf, recvbuf, size);
 }
 
 }  // namespace lci

--- a/src/collective/alltoall.cpp
+++ b/src/collective/alltoall.cpp
@@ -8,8 +8,8 @@ namespace lci
 void alltoall_x::call_impl(const void* sendbuf, void* recvbuf, size_t size,
                            runtime_t runtime, device_t device,
                            endpoint_t endpoint,
-                           matching_engine_t matching_engine,
-                           comp_t comp, comp_semantic_t comp_semantic) const
+                           matching_engine_t matching_engine, comp_t comp,
+                           comp_semantic_t comp_semantic) const
 {
   int seqnum = get_sequence_number();
 
@@ -29,8 +29,8 @@ void alltoall_x::call_impl(const void* sendbuf, void* recvbuf, size_t size,
       lci::comp_signal(comp, status_t(errorcode_t::done));
     }
     LCI_DBG_Log(LOG_TRACE, "collective",
-                "leave alltoall %d (sendbuf %p recvbuf %p size %lu)\n",
-                seqnum, sendbuf, recvbuf, size);
+                "leave alltoall %d (sendbuf %p recvbuf %p size %lu)\n", seqnum,
+                sendbuf, recvbuf, size);
     return;
   }
 

--- a/tests/unit/collective/all.cpp
+++ b/tests/unit/collective/all.cpp
@@ -153,13 +153,35 @@ TEST(COMM_COLL, alltoall)
   int rank = lci::get_rank_me();
   int nranks = lci::get_rank_n();
 
-  std::vector<uint64_t> sendbuf(nranks, rank);
+  std::vector<uint64_t> sendbuf(nranks);
   std::vector<uint64_t> recvbuf(nranks, -1);
+  for (int i = 0; i < nranks; ++i) {
+    sendbuf[i] = rank * nranks + i;
+  }
 
   lci::alltoall(sendbuf.data(), recvbuf.data(), sizeof(uint64_t));
 
   for (int i = 0; i < nranks; ++i) {
-    ASSERT_EQ(recvbuf[i], i);
+    ASSERT_EQ(recvbuf[i], i * nranks + rank);
+  }
+
+  std::vector<uint64_t> nonblocking_sendbuf(nranks);
+  std::vector<uint64_t> nonblocking_recvbuf(nranks, -1);
+  for (int i = 0; i < nranks; ++i) {
+    nonblocking_sendbuf[i] = (rank + 1) * nranks + i;
+  }
+
+  lci::comp_t sync = lci::alloc_sync();
+  lci::alltoall_x(nonblocking_sendbuf.data(), nonblocking_recvbuf.data(),
+                  sizeof(uint64_t))
+      .comp(sync)();
+  while (!lci::sync_test(sync, nullptr)) {
+    lci::progress();
+  }
+  lci::free_comp(&sync);
+
+  for (int i = 0; i < nranks; ++i) {
+    ASSERT_EQ(nonblocking_recvbuf[i], (i + 1) * nranks + rank);
   }
 
   lci::g_runtime_fina();


### PR DESCRIPTION
Summary:
- Add optional `comp_t` completion support to `alltoall`.
- Rework alltoall onto a direct graph of send/recv nodes, preserving blocking behavior when `comp` is omitted.
- Strengthen the alltoall unit test and add nonblocking coverage.

Validation:
- Local: `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DLCI_NETWORK_BACKENDS=ibv -DLCI_USE_TCMALLOC=OFF -DLCI_DEBUG=ON` passed.
- Local: `cmake --build build --target lci_test-collective-all` passed.
- Local: `ctest -R collective-all --output-on-failure --timeout 120` could not run because this host has no available LCI network backend.
- Remote banff20-14: `cmake --build build --target test-collective-all -j 8` passed.
- Remote banff20-14: `ctest -R collective-all --output-on-failure --timeout 180` passed: 7/7 tests.

Tracking issue: https://github.com/JiakunYan/lci/issues/7
