### PR TITLE
Reduce CI OFI CQ depth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
               -DLCI_NETWORK_BACKENDS=ofi,ibv
               -DLCI_USE_TCMALLOC=OFF
               -DLCI_USE_REG_CACHE=${{ matrix.reg_cache }}
-              -DLCI_BACKEND_MAX_CQES_DEFAULT=4096
+              -DLCI_BACKEND_MAX_CQES_DEFAULT=1024
               -DCMAKE_VERBOSE_MAKEFILE=ON
             "
 


### PR DESCRIPTION
## Summary

- Reduce the GitHub Actions CI OFI CQ default from `4096` to `1024`.
- This makes hosted-runner OFI endpoint allocation less resource hungry after the post-merge `master` CI failure at `fi_enable(ofi_ep)` with libfabric `ENOMEM`.

Fixes #173

## Validation

- `git diff --check`
- Verified `.github/workflows/ci.yml` contains `-DLCI_BACKEND_MAX_CQES_DEFAULT=1024`
