### PR TITLE
Support 4-byte OFI CQ data providers

### DIFF
--- a/.github/workflows/ci-downstream-lcw.yml
+++ b/.github/workflows/ci-downstream-lcw.yml
@@ -46,6 +46,7 @@ jobs:
                 -DLCI_DEBUG=ON \
                 -DLCI_NETWORK_BACKENDS=ofi \
                 -DLCI_USE_TCMALLOC=OFF \
+                -DLCI_BACKEND_MAX_CQES_DEFAULT=1024 \
                 -DCMAKE_VERBOSE_MAKEFILE=ON \
                 -DLCW_DEBUG=ON \
                 -DLCW_USE_CTEST_LAUNCHER=${{ github.workspace }}/lci/lcrun \

--- a/.github/workflows/ci-downstream-reconverse.yml
+++ b/.github/workflows/ci-downstream-reconverse.yml
@@ -46,6 +46,7 @@ jobs:
                 -DLCI_DEBUG=ON \
                 -DLCI_NETWORK_BACKENDS=ofi \
                 -DLCI_USE_TCMALLOC=OFF \
+                -DLCI_BACKEND_MAX_CQES_DEFAULT=1024 \
                 -DCMAKE_VERBOSE_MAKEFILE=ON \
                 -DRECONVERSE_AUTOFETCH_LCI2=ON \
                 -DRECONVERSE_TEST_LAUNCHER=${{ github.workspace }}/lci/lcrun \

--- a/src/core/communicate.cpp
+++ b/src/core/communicate.cpp
@@ -157,46 +157,36 @@ void set_protocol(const post_comm_args_t& args,
     force_zcopy = true;
   }
 #endif  // LCI_USE_CUDA || LCI_USE_HIP
+  const bool is_out_msg = args.direction == direction_t::OUT &&
+                          traits.local_buffer_only;
+  const bool needs_src_rank_in_msg =
+      is_out_msg && args.device.p_impl->needs_src_rank_in_msg();
+  const bool needs_tag_rcomp_in_msg =
+      is_out_msg && state.rhandler &&
+      (args.tag > args.runtime.get_attr_max_imm_tag() ||
+       state.rhandler > args.runtime.get_attr_max_imm_rcomp());
+
   // determine the message size if we are using the eager protocol
   size_t msg_size_if_eager = args.size;
-  const bool needs_src_rank_in_msg =
-      args.direction == direction_t::OUT && traits.local_buffer_only &&
-      args.device.p_impl->needs_src_rank_in_msg();
+  if (needs_tag_rcomp_in_msg) {
+    msg_size_if_eager += sizeof(args.tag) + sizeof(state.rhandler);
+  }
   if (needs_src_rank_in_msg) {
     msg_size_if_eager += sizeof(int);
   }
-  if (args.direction == direction_t::OUT && state.rhandler) {
-    // send/am/put_signal with eager protocol
-    if (args.tag > args.runtime.get_attr_max_imm_tag() ||
-        state.rhandler > args.runtime.get_attr_max_imm_rcomp()) {
-      msg_size_if_eager += sizeof(args.tag) + sizeof(state.rhandler);
-    }
-  }
+  const bool needs_eager_metadata =
+      needs_tag_rcomp_in_msg || needs_src_rank_in_msg;
 
   if (args.direction == direction_t::IN && traits.local_buffer_only) {
     state.protocol = protocol_t::recv;
-  } else if (needs_src_rank_in_msg) {
-    // The source-rank tail needs a packet/bcopy payload.  Prefer bcopy for
-    // host buffers (including explicit host MRs) when it fits; otherwise use
-    // rendezvous rather than inject/eager-zcopy, which cannot append metadata.
-    if (msg_size_if_eager <= traits.max_bcopy_size && !force_zcopy) {
-      state.protocol = protocol_t::eager_bcopy;
-      state.piggyback_src_rank_in_msg = true;
-      if (msg_size_if_eager > args.size + sizeof(int)) {
-        state.piggyback_tag_rcomp_in_msg = true;
-      }
-    } else {
-      state.protocol = protocol_t::rdv_zcopy;
-      state.piggyback_src_rank_in_msg = true;
-    }
-  } else if (args.direction == direction_t::OUT && traits.local_buffer_only &&
+  } else if (is_out_msg &&
              (msg_size_if_eager > traits.max_bcopy_size || force_zcopy)) {
-    // We use the rendezvous protocol if
-    // 1. we are doing a send/am, and
-    // 1.1 The size of the data is larger than the maximum buffer-copy size, or
-    // 1.2 We force the use of the zero-copy protocol.
+    // We use rendezvous for send/am when the eager payload, including metadata,
+    // does not fit in a packet or when device buffers force zero-copy.  RTS
+    // already carries tag/rcomp; only source rank needs an extra RTS tail.
     state.protocol = protocol_t::rdv_zcopy;
-  } else if (msg_size_if_eager <= traits.max_inject_size &&
+    state.piggyback_src_rank_in_msg = needs_src_rank_in_msg;
+  } else if (!needs_eager_metadata && msg_size_if_eager <= traits.max_inject_size &&
              args.direction == direction_t::OUT &&
              args.comp_semantic == comp_semantic_t::memory && !force_zcopy) {
     // We use the inject protocol only if the five conditions are met:
@@ -205,13 +195,15 @@ void set_protocol(const post_comm_args_t& args,
     // 3. The direction is OUT, and
     // 4. The completion type is buffer.
     // 5. We are not forcing the use of the zero-copy protocol.
+    //
+    // Inject is skipped when eager metadata is needed because there is no
+    // packet payload available for appending tag/rcomp or source-rank tails.
     state.protocol = protocol_t::inject;
-  } else if (args.mr.is_empty() && msg_size_if_eager <= traits.max_bcopy_size &&
-             !force_zcopy) {
+  } else if ((args.mr.is_empty() || needs_eager_metadata) &&
+             msg_size_if_eager <= traits.max_bcopy_size && !force_zcopy) {
     state.protocol = protocol_t::eager_bcopy;
-    if (msg_size_if_eager > args.size) {
-      state.piggyback_tag_rcomp_in_msg = true;
-    }
+    state.piggyback_tag_rcomp_in_msg = needs_tag_rcomp_in_msg;
+    state.piggyback_src_rank_in_msg = needs_src_rank_in_msg;
   } else {
     state.protocol = protocol_t::eager_zcopy;
   }
@@ -231,7 +223,8 @@ void set_local_comp(const post_comm_args_t& args, const post_comm_traits_t&,
 
 // state in: protocol, rhandler
 // state out: imm_data
-void set_immediate_data(const post_comm_args_t& args, const post_comm_traits_t&,
+void set_immediate_data(const post_comm_args_t& args,
+                        const post_comm_traits_t& traits,
                         post_comm_state_t& state)
 {
   // set immediate data
@@ -242,17 +235,22 @@ void set_immediate_data(const post_comm_args_t& args, const post_comm_traits_t&,
     // bit 29-30: imm_data_msg_type_t
     imm_data = set_bits32(0, IMM_DATA_MSG_RTS, 2, 29);
   } else if (args.direction == direction_t::OUT && state.rhandler) {
-    // send/am/put_signal with eager protocol
     if (args.tag <= args.runtime.get_attr_max_imm_tag() &&
         state.rhandler <= args.runtime.get_attr_max_imm_rcomp()) {
-      // is_fastpath (1) ; rhandler (15) ; tag (16)
+      // send/am/put_signal fastpath: is_fastpath (1) ; rhandler (15) ; tag (16)
       imm_data = set_bits32(imm_data, 1, 1, 31);  // is_fastpath
       imm_data = set_bits32(imm_data, args.tag,
                             args.runtime.get_attr_imm_nbits_tag(), 0);
       imm_data = set_bits32(imm_data, state.rhandler,
                             args.runtime.get_attr_imm_nbits_rcomp(), 16);
     } else {
-      // is_fastpath (0) ; msg_type (2)
+      LCI_Assert(traits.local_buffer_only,
+                 "RMA put-with-signal requires tag (%lu) and remote "
+                 "completion (%lu) to fit in immediate data\n",
+                 static_cast<unsigned long>(args.tag),
+                 static_cast<unsigned long>(state.rhandler));
+      // send/am slowpath: is_fastpath (0) ; msg_type (2).  The tag and
+      // rhandler are appended to the FI_MSG payload by set_packet_if_needed().
       static_assert(IMM_DATA_MSG_EAGER == 0, "Unexpected IMM_DATA_MSG_EAGER");
     }
   }

--- a/src/core/communicate.cpp
+++ b/src/core/communicate.cpp
@@ -157,8 +157,8 @@ void set_protocol(const post_comm_args_t& args,
     force_zcopy = true;
   }
 #endif  // LCI_USE_CUDA || LCI_USE_HIP
-  const bool is_out_msg = args.direction == direction_t::OUT &&
-                          traits.local_buffer_only;
+  const bool is_out_msg =
+      args.direction == direction_t::OUT && traits.local_buffer_only;
   const bool needs_src_rank_in_msg =
       is_out_msg && args.device.p_impl->needs_src_rank_in_msg();
   const bool needs_tag_rcomp_in_msg =
@@ -186,7 +186,8 @@ void set_protocol(const post_comm_args_t& args,
     // already carries tag/rcomp; only source rank needs an extra RTS tail.
     state.protocol = protocol_t::rdv_zcopy;
     state.piggyback_src_rank_in_msg = needs_src_rank_in_msg;
-  } else if (!needs_eager_metadata && msg_size_if_eager <= traits.max_inject_size &&
+  } else if (!needs_eager_metadata &&
+             msg_size_if_eager <= traits.max_inject_size &&
              args.direction == direction_t::OUT &&
              args.comp_semantic == comp_semantic_t::memory && !force_zcopy) {
     // We use the inject protocol only if the five conditions are met:

--- a/src/core/communicate.cpp
+++ b/src/core/communicate.cpp
@@ -57,6 +57,7 @@ struct post_comm_traits_t {
 struct post_comm_state_t {
   rcomp_t rhandler = 0;
   bool piggyback_tag_rcomp_in_msg = false;
+  bool piggyback_src_rank_in_msg = false;
   net_imm_data_t imm_data = 0;
   packet_t* packet = nullptr;
   size_t packet_size_to_send = 0;
@@ -144,7 +145,7 @@ void resolve_rhandler(const post_comm_args_t& args,
 }
 
 // state in: rhandler
-// state out: protocol, piggyback_tag_rcomp_in_msg
+// state out: protocol, piggyback_tag_rcomp_in_msg, piggyback_src_rank_in_msg
 void set_protocol(const post_comm_args_t& args,
                   const post_comm_traits_t& traits, post_comm_state_t& state)
 {
@@ -158,6 +159,12 @@ void set_protocol(const post_comm_args_t& args,
 #endif  // LCI_USE_CUDA || LCI_USE_HIP
   // determine the message size if we are using the eager protocol
   size_t msg_size_if_eager = args.size;
+  const bool needs_src_rank_in_msg =
+      args.direction == direction_t::OUT && traits.local_buffer_only &&
+      args.device.p_impl->needs_src_rank_in_msg();
+  if (needs_src_rank_in_msg) {
+    msg_size_if_eager += sizeof(int);
+  }
   if (args.direction == direction_t::OUT && state.rhandler) {
     // send/am/put_signal with eager protocol
     if (args.tag > args.runtime.get_attr_max_imm_tag() ||
@@ -168,6 +175,20 @@ void set_protocol(const post_comm_args_t& args,
 
   if (args.direction == direction_t::IN && traits.local_buffer_only) {
     state.protocol = protocol_t::recv;
+  } else if (needs_src_rank_in_msg) {
+    // The source-rank tail needs a packet/bcopy payload.  Prefer bcopy for
+    // host buffers (including explicit host MRs) when it fits; otherwise use
+    // rendezvous rather than inject/eager-zcopy, which cannot append metadata.
+    if (msg_size_if_eager <= traits.max_bcopy_size && !force_zcopy) {
+      state.protocol = protocol_t::eager_bcopy;
+      state.piggyback_src_rank_in_msg = true;
+      if (msg_size_if_eager > args.size + sizeof(int)) {
+        state.piggyback_tag_rcomp_in_msg = true;
+      }
+    } else {
+      state.protocol = protocol_t::rdv_zcopy;
+      state.piggyback_src_rank_in_msg = true;
+    }
   } else if (args.direction == direction_t::OUT && traits.local_buffer_only &&
              (msg_size_if_eager > traits.max_bcopy_size || force_zcopy)) {
     // We use the rendezvous protocol if
@@ -238,7 +259,8 @@ void set_immediate_data(const post_comm_args_t& args, const post_comm_traits_t&,
   state.imm_data = imm_data;
 }
 
-// state in: protocol, rhandler, piggyback_tag_rcomp_in_msg
+// state in: protocol, rhandler, piggyback_tag_rcomp_in_msg,
+//           piggyback_src_rank_in_msg
 // state.out: packet, user_provided_packet
 error_t set_packet_if_needed(const post_comm_args_t& args,
                              [[maybe_unused]] const post_comm_traits_t& traits,
@@ -286,6 +308,14 @@ error_t set_packet_if_needed(const post_comm_args_t& args,
       memcpy((char*)buffer + state.packet_size_to_send, &state.rhandler,
              sizeof(state.rhandler));
       state.packet_size_to_send += sizeof(state.rhandler);
+    }
+    if (state.piggyback_src_rank_in_msg) {
+      char* buffer = (char*)state.packet->get_payload_address();
+      int src_rank = get_rank_me();
+      memcpy(buffer + state.packet_size_to_send, &src_rank, sizeof(src_rank));
+      state.packet_size_to_send += sizeof(src_rank);
+    }
+    if (state.piggyback_tag_rcomp_in_msg || state.piggyback_src_rank_in_msg) {
       LCI_Assert(state.packet_size_to_send <= traits.max_bcopy_size, "");
     }
     if (state.packet_size_to_send >
@@ -456,10 +486,15 @@ error_t post_network_op(const post_comm_args_t& args,
       // rendezvous send
       // build the rts message
       rts_msg_t* p_rts;
-      if (sizeof(rts_msg_t) <= traits.max_inject_size) {
+      size_t rts_size_to_send = sizeof(rts_msg_t);
+      if (state.piggyback_src_rank_in_msg) {
+        rts_size_to_send += sizeof(int);
+      }
+      if (!state.piggyback_src_rank_in_msg &&
+          sizeof(rts_msg_t) <= traits.max_inject_size) {
         p_rts = reinterpret_cast<rts_msg_t*>(malloc(sizeof(rts_msg_t)));
       } else {
-        LCI_Assert(sizeof(rts_msg_t) <= traits.max_bcopy_size,
+        LCI_Assert(rts_size_to_send <= traits.max_bcopy_size,
                    "The rts message is too large\n");
         p_rts = static_cast<rts_msg_t*>(state.packet->get_payload_address());
       }
@@ -467,15 +502,21 @@ error_t post_network_op(const post_comm_args_t& args,
       p_rts->tag = args.tag;
       p_rts->rcomp = state.rhandler;
       p_rts->size = args.size;
+      if (state.piggyback_src_rank_in_msg) {
+        int src_rank = get_rank_me();
+        memcpy(reinterpret_cast<char*>(p_rts) + sizeof(rts_msg_t), &src_rank,
+               sizeof(src_rank));
+      }
       // post send for the rts message
-      if (sizeof(rts_msg_t) <= traits.max_inject_size) {
+      if (!state.piggyback_src_rank_in_msg &&
+          sizeof(rts_msg_t) <= traits.max_inject_size) {
         error = args.endpoint.p_impl->post_sends(
             args.rank, p_rts, sizeof(rts_msg_t), state.imm_data, nullptr,
             args.allow_retry);
         free(p_rts);
       } else {
         error = args.endpoint.p_impl->post_send(
-            args.rank, p_rts, sizeof(rts_msg_t),
+            args.rank, p_rts, rts_size_to_send,
             state.packet->get_mr(args.device), state.imm_data, nullptr,
             args.allow_retry);
       }

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -15,6 +15,7 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
   uint32_t imm_data = net_status.imm_data;
   tag_t tag = 0;
   rcomp_t remote_comp = 0;
+  int src_rank = net_status.rank;
   bool is_fastpath = get_bits32(imm_data, 1, 31);
   imm_data_msg_type_t msg_type;
   if (is_fastpath) {
@@ -23,6 +24,16 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
     msg_type = IMM_DATA_MSG_EAGER;
   } else {
     msg_type = static_cast<imm_data_msg_type_t>(get_bits32(imm_data, 2, 29));
+  }
+  if (endpoint.get_impl()->device.p_impl->needs_src_rank_in_msg() &&
+      (msg_type == IMM_DATA_MSG_EAGER || msg_type == IMM_DATA_MSG_RTS)) {
+    LCI_Assert(msg_size >= sizeof(src_rank),
+               "Message missing source-rank metadata\n");
+    msg_size -= sizeof(src_rank);
+    memcpy(&src_rank, (char*)packet->get_payload_address() + msg_size,
+           sizeof(src_rank));
+  }
+  if (!is_fastpath) {
     if (msg_type == IMM_DATA_MSG_EAGER) {
       // get tag and rcomp by looking at the message payload
       msg_size -= sizeof(remote_comp);
@@ -40,7 +51,7 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
         // we get an active message
         status_t status;
         status.set_done();
-        status.rank = net_status.rank;
+        status.rank = src_rank;
         status.tag = tag;
         if (reinterpret_cast<comp_impl_t*>(entry.value)->attr.zero_copy_am) {
           status.buffer = packet->get_payload_address();
@@ -59,10 +70,9 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
         matching_engine_impl_t* p_matching_engine =
             reinterpret_cast<matching_engine_impl_t*>(entry.value);
         auto key = p_matching_engine->make_key(
-            net_status.rank, tag,
-            static_cast<matching_policy_t>(entry.metadata));
+            src_rank, tag, static_cast<matching_policy_t>(entry.metadata));
         packet->local_context.is_eager = true;
-        packet->local_context.rank = net_status.rank;
+        packet->local_context.rank = src_rank;
         packet->local_context.tag = tag;
         packet->local_context.size = msg_size;
         auto ret = p_matching_engine->insert(
@@ -74,7 +84,7 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
       break;
     }
     case IMM_DATA_MSG_RTS:
-      packet->local_context.rank = net_status.rank;
+      packet->local_context.rank = src_rank;
       handle_rdv_rts(runtime, endpoint, packet);
       break;
     case IMM_DATA_MSG_RTR:
@@ -119,9 +129,8 @@ void progress_write(endpoint_t endpoint, const net_status_t& net_status)
       handle_rdv_local_write(endpoint, ectx);
     } else if (ectx->imm_data_rank != -1) {
       // send immediate data
-      error_t error = endpoint.get_impl()->post_sends(
-          ectx->imm_data_rank, nullptr, 0, ectx->imm_data, nullptr,
-          false /* allow_retry */);
+      error_t error = endpoint.get_impl()->post_empty_signal(
+          ectx->imm_data_rank, ectx->imm_data, false /* allow_retry */);
       LCI_Assert(error.is_done(), "Unexpected error %s\n", error.get_str());
     }  // else: this is a RDMA write buffers or rendezvous with writeimm
     delete ectx;

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -5,7 +5,7 @@
 
 namespace lci
 {
-void progress_recv(runtime_t runtime, endpoint_t endpoint,
+void progress_recv(runtime_t runtime, device_t device, endpoint_t endpoint,
                    const net_status_t& net_status)
 {
   LCI_PCOUNTER_ADD(net_recv_comp, 1)
@@ -25,7 +25,7 @@ void progress_recv(runtime_t runtime, endpoint_t endpoint,
   } else {
     msg_type = static_cast<imm_data_msg_type_t>(get_bits32(imm_data, 2, 29));
   }
-  if (endpoint.get_impl()->device.p_impl->needs_src_rank_in_msg() &&
+  if (device.p_impl->needs_src_rank_in_msg() &&
       (msg_type == IMM_DATA_MSG_EAGER || msg_type == IMM_DATA_MSG_RTS)) {
     LCI_Assert(msg_size >= sizeof(src_rank),
                "Message missing source-rank metadata\n");
@@ -248,7 +248,7 @@ error_t progress_x::call_impl(runtime_t runtime, device_t device,
       auto status = statuses[i];
       if (status.opcode == net_opcode_t::RECV) {
         device.p_impl->consume_recvs(1);
-        progress_recv(runtime, endpoint, status);
+        progress_recv(runtime, device, endpoint, status);
       } else if (status.opcode == net_opcode_t::SEND) {
         progress_send(status);
       } else if (status.opcode == net_opcode_t::WRITE) {

--- a/src/network/endpoint_inline.hpp
+++ b/src/network/endpoint_inline.hpp
@@ -52,6 +52,26 @@ inline error_t endpoint_impl_t::post_sends(int rank, void* buffer, size_t size,
   return error;
 }
 
+inline error_t endpoint_impl_t::post_empty_signal(int rank,
+                                                  net_imm_data_t imm_data,
+                                                  bool allow_retry,
+                                                  bool force_post)
+{
+  // RMA put-with-signal fallback paths emulate remote immediate completion
+  // with an empty FI_MSG EAGER notification.  On OFI providers that cannot
+  // carry both LCI immediate data and source rank in CQ data, progress_recv()
+  // expects the source rank as the final message-payload field for EAGER/RTS
+  // messages.  Keep the original LCI imm_data in CQ data and append only the
+  // source-rank metadata payload here.
+  if (device.p_impl->needs_src_rank_in_msg()) {
+    int src_rank = get_rank_me();
+    return post_sends(rank, &src_rank, sizeof(src_rank), imm_data, nullptr,
+                      allow_retry, force_post);
+  }
+  return post_sends(rank, nullptr, 0, imm_data, nullptr, allow_retry,
+                    force_post);
+}
+
 inline error_t endpoint_impl_t::post_send(int rank, void* buffer, size_t size,
                                           mr_t mr, net_imm_data_t imm_data,
                                           void* user_context, bool allow_retry,
@@ -168,8 +188,7 @@ inline error_t endpoint_impl_t::post_putImms_fallback(
     // we do not allow retry for post_sends
     // otherwise the above puts might be posted again
     // XXX: but even if puts is posted again, it is not a error
-    error_t error = post_sends(rank, nullptr, 0, imm_data, nullptr,
-                               false /* allow_retry */);
+    error_t error = post_empty_signal(rank, imm_data, false /* allow_retry */);
     LCI_Assert(error.is_done(), "Unexpected error %s\n", error.get_str());
   }
   return error;

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -38,6 +38,7 @@ class device_impl_t
                                  void* user_context) = 0;
   virtual size_t post_recvs_impl(void* buffers[], size_t size, size_t count,
                                  mr_t mr, void* usesr_contexts[]) = 0;
+  virtual bool needs_src_rank_in_msg() const { return false; }
 
   // wrapper functions
   endpoint_t alloc_endpoint(endpoint_t::attr_t attr);
@@ -144,6 +145,9 @@ class endpoint_impl_t
   inline error_t post_sends(int rank, void* buffer, size_t size,
                             net_imm_data_t imm_data, void* user_context,
                             bool allow_retry = true, bool force_post = false);
+  inline error_t post_empty_signal(int rank, net_imm_data_t imm_data,
+                                   bool allow_retry = true,
+                                   bool force_post = false);
   inline error_t post_send(int rank, void* buffer, size_t size, mr_t mr,
                            net_imm_data_t imm_data, void* user_context,
                            bool allow_retry = true, bool force_post = false);

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -143,6 +143,8 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
           fi_tostr(&(ofi_info->domain_attr->data_progress), FI_TYPE_PROGRESS));
   LCI_Log(LOG_INFO, "ofi", "Capacities: %s\n",
           fi_tostr(&(ofi_info->caps), FI_TYPE_CAPS));
+  LCI_Log(LOG_INFO, "ofi", "CQ data size: %lu\n",
+          ofi_info->domain_attr->cq_data_size);
   LCI_Log(LOG_INFO, "ofi", "Mode: %s\n",
           fi_tostr(&(ofi_info->mode), FI_TYPE_MODE));
   LCI_Log(LOG_DEBUG, "ofi", "Fi_info provided: %s\n",
@@ -179,6 +181,12 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
         "as required by the libfabric max_msg_size attribute. Turn off this "
         "warning by `export LCI_MAX_SINGLE_MESSAGE_SIZE=%lu`\n",
         attr.max_msg_size, attr.max_msg_size);
+  }
+  if (ofi_info->domain_attr->cq_data_size < 8) {
+    LCI_Log(LOG_INFO, "ofi",
+            "Use 4-byte OFI CQ data path: CQ data carries LCI immediate "
+            "data; source rank is carried by LCI core message metadata when "
+            "needed\n");
   }
   // Check put with immediate support.
   attr.support_putimm = true;
@@ -219,6 +227,7 @@ ofi_device_impl_t::ofi_device_impl_t(net_context_t context_,
 {
   auto p_ofi_context = static_cast<ofi_net_context_impl_t*>(net_context.p_impl);
   ofi_domain_attr = p_ofi_context->ofi_info->domain_attr;
+  ofi_cq_data_size = ofi_domain_attr->cq_data_size;
   // Create domain.
   FI_SAFECALL(fi_domain(p_ofi_context->ofi_fabric, p_ofi_context->ofi_info,
                         &ofi_domain, nullptr));
@@ -410,6 +419,7 @@ ofi_endpoint_impl_t::ofi_endpoint_impl_t(device_t device_, attr_t attr_)
       ofi_domain_attr(p_ofi_device->ofi_domain_attr),
       ofi_ep(p_ofi_device->ofi_ep),
       peer_addrs(p_ofi_device->peer_addrs),
+      ofi_cq_data_size(p_ofi_device->ofi_cq_data_size),
       ofi_lock_mode(p_ofi_device->ofi_lock_mode),
       lock(p_ofi_device->lock)
 {

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -96,8 +96,11 @@ class ofi_device_impl_t : public lci::device_impl_t
                          void* user_context) override;
   size_t post_recvs_impl(void* buffers[], size_t size, size_t count, mr_t mr,
                          void* usesr_contexts[]) override;
+  bool needs_src_rank_in_msg() const override { return !use_8byte_cq_data(); }
+  bool use_8byte_cq_data() const { return ofi_cq_data_size >= 8; }
 
   struct fi_domain_attr* ofi_domain_attr;
+  size_t ofi_cq_data_size;
   struct fid_domain* ofi_domain;
   struct fid_ep* ofi_ep;
   struct fid_cq* ofi_cq;
@@ -141,6 +144,7 @@ class ofi_endpoint_impl_t : public lci::endpoint_impl_t
   struct fi_domain_attr* ofi_domain_attr;
   struct fid_ep* ofi_ep;
   std::vector<fi_addr_t>& peer_addrs;
+  size_t ofi_cq_data_size;
   uint64_t& ofi_lock_mode;
   spinlock_t& lock;
 };

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -6,6 +6,26 @@
 
 namespace lci
 {
+namespace ofi_detail
+{
+// OFI providers with >=8-byte CQ data keep the historical LCI wire format:
+//   CQ data = (source rank << 32) | imm_data.
+// Providers with only 4-byte CQ data use CQ data for the original LCI
+// imm_data.  Source rank metadata, when required, is appended and decoded by
+// the LCI core eager/RTS message payload path.
+inline bool use_8byte_cq_data(size_t cq_data_size) { return cq_data_size >= 8; }
+
+inline uint64_t make_msg_cq_data(size_t cq_data_size, int my_rank,
+                                 net_imm_data_t imm_data)
+{
+  if (use_8byte_cq_data(cq_data_size)) {
+    return (uint64_t)my_rank << 32 | imm_data;
+  } else {
+    return imm_data;
+  }
+}
+}  // namespace ofi_detail
+
 inline uint64_t ofi_device_impl_t::get_rkey(mr_impl_t* mr)
 {
   ofi_mr_impl_t& p_mr = *static_cast<ofi_mr_impl_t*>(mr);
@@ -22,26 +42,47 @@ inline size_t ofi_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
   LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_POLL);
   if (ne > 0) {
     // Got an entry here
-    if (p_statuses) {
-      for (int j = 0; j < ne; j++) {
-        net_status_t& status = p_statuses[j];
-        if (fi_entries[j].flags & FI_RECV) {
+    for (int j = 0; j < ne; j++) {
+      net_status_t local_status;
+      net_status_t& status = p_statuses ? p_statuses[j] : local_status;
+      if (p_statuses) {
+        status.rank = -1;
+        status.user_context = nullptr;
+        status.length = 0;
+        status.imm_data = 0;
+      }
+      if (fi_entries[j].flags & FI_RECV) {
+        if (p_statuses) {
           status.opcode = net_opcode_t::RECV;
           status.user_context = fi_entries[j].op_context;
           status.length = fi_entries[j].len;
-          status.imm_data = fi_entries[j].data & ((1ULL << 32) - 1);
-          status.rank = (int)(fi_entries[j].data >> 32);
-        } else if (fi_entries[j].flags & FI_REMOTE_WRITE) {
+          status.imm_data = static_cast<net_imm_data_t>(fi_entries[j].data &
+                                                        ((1ULL << 32) - 1));
+          if (use_8byte_cq_data()) {
+            status.rank = static_cast<int>(fi_entries[j].data >> 32);
+          }
+        }
+      } else if (fi_entries[j].flags & FI_REMOTE_WRITE) {
+        if (p_statuses) {
           status.opcode = net_opcode_t::REMOTE_WRITE;
           status.user_context = NULL;
-          status.imm_data = fi_entries[j].data;
-        } else if (fi_entries[j].flags & FI_SEND) {
+          status.imm_data = static_cast<net_imm_data_t>(fi_entries[j].data);
+          // RMA completions do not carry LCI message payload metadata.  On the
+          // 4-byte CQ-data path the immediate value is preserved and source
+          // rank is intentionally unavailable.
+        }
+      } else if (fi_entries[j].flags & FI_SEND) {
+        if (p_statuses) {
           status.opcode = net_opcode_t::SEND;
           status.user_context = fi_entries[j].op_context;
-        } else if (fi_entries[j].flags & FI_WRITE) {
+        }
+      } else if (fi_entries[j].flags & FI_WRITE) {
+        if (p_statuses) {
           status.opcode = net_opcode_t::WRITE;
           status.user_context = fi_entries[j].op_context;
-        } else {
+        }
+      } else {
+        if (p_statuses) {
           LCI_DBG_Assert(fi_entries[j].flags & FI_READ,
                          "Unexpected OFI opcode!\n");
           status.opcode = net_opcode_t::READ;
@@ -114,10 +155,11 @@ inline size_t ofi_device_impl_t::post_recvs_impl(void* buffers[], size_t size,
   for (size_t i = 0; i < count; i++) {
     error = fi_recv(ofi_ep, buffers[i], size, mr_desc, FI_ADDR_UNSPEC,
                     user_contexts[i]);
-    if (error == FI_SUCCESS)
+    if (error == FI_SUCCESS) {
       ++n_posted;
-    else
+    } else {
       break;
+    }
   }
   LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_RECV);
   if (error == FI_SUCCESS || error == -FI_EAGAIN)
@@ -143,7 +185,7 @@ inline error_t ofi_endpoint_impl_t::post_sends_impl(int rank, void* buffer,
   msg.iov_count = 1;
   msg.addr = peer_addrs[rank];
   msg.context = user_context;
-  msg.data = (uint64_t)my_rank << 32 | imm_data;
+  msg.data = ofi_detail::make_msg_cq_data(ofi_cq_data_size, my_rank, imm_data);
   LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
   ssize_t ret =
       fi_sendmsg(ofi_ep, &msg, FI_INJECT | FI_COMPLETION | FI_REMOTE_CQ_DATA);
@@ -168,15 +210,16 @@ inline error_t ofi_endpoint_impl_t::post_send_impl(int rank, void* buffer,
                                                    bool /*high_priority*/)
 {
   LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
+  uint64_t cq_data =
+      ofi_detail::make_msg_cq_data(ofi_cq_data_size, my_rank, imm_data);
   ssize_t ret = fi_senddata(ofi_ep, buffer, size, ofi_detail::get_mr_desc(mr),
-                            (uint64_t)my_rank << 32 | imm_data,
-                            peer_addrs[rank], user_context);
+                            cq_data, peer_addrs[rank], user_context);
   LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
   if (ret == FI_SUCCESS)
     return errorcode_t::posted;
-  else if (ret == -FI_EAGAIN)
+  else if (ret == -FI_EAGAIN) {
     return errorcode_t::retry_nomem;
-  else {
+  } else {
     FI_SAFECALL_RET(ret);
   }
 }


### PR DESCRIPTION
## Summary
- Preserve the existing 8-byte OFI CQ-data format when providers support it: `(source_rank << 32) | imm_data`.
- Add a 4-byte OFI CQ-data path for providers such as OPX where CQ data carries the original LCI `imm_data`.
- Carry source rank through LCI core message metadata, reusing/extending the existing oversized eager tag/rcomp piggyback style.
- Add a source-rank metadata path for RTS and fallback empty-signal notifications while leaving RTR/FIN and RMA remote-write immediate source rank reporting unchanged.
- Use device-level metadata policy during receive progress so collective/downstream callers can pass an empty progress endpoint safely.
- Cap downstream LCW and Reconverse OFI CQ depth to match primary CI and avoid multi-device OFI resource exhaustion on GitHub runners.

## Validation
- `./format.sh && git diff --exit-code`
- `cmake --build build --target all -j4`
- `ctest --test-dir build --output-on-failure -R 'test-collective-all|test-benchmark-bench_put_bw|test-example-pingpong_am_mt' -j1`
- `ctest --test-dir build -R '^test-benchmark-bench_put_bw$' --output-on-failure --timeout 60`
- `ctest --test-dir build -R '^test-collective-all(-[0-9]+)?$' --output-on-failure --timeout 120`
- `git diff --check`
- Local LCW build against this LCI worktree with `-DLCI_BACKEND_MAX_CQES_DEFAULT=1024`
- Local LCW `ctest -R 'pingpong_mt'` — passed 8/8

## Notes
- Not yet validated on OPX hardware; this is a correctness-oriented protocol layout change based on OPX's source-confirmed 4-byte CQ-data limit.

Fixes #177
