### PR TITLE
Report peer rank for completion-less AM failures

### DIFF
--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -97,28 +97,47 @@ void progress_send(const net_status_t& net_status)
   free_ctx_and_signal_comp(internal_ctx);
 }
 
-static bool cleanup_failed_simple_operation(const net_status_t& net_status,
-                                            int* failed_rank)
+static bool get_failed_peer_rank(const net_status_t& net_status,
+                                 int* failed_rank)
 {
-  if (net_status.user_context == nullptr) return false;
+  // Extract peer identity before cleanup. A rank is still useful diagnostic
+  // information when the operation did not request a completion object.
+  int context_rank = -1;
+  if (net_status.user_context != nullptr) {
+    internal_context_t* internal_ctx =
+        static_cast<internal_context_t*>(net_status.user_context);
+    if (!internal_ctx->is_extended) {
+      context_rank = internal_ctx->rank;
+    }
+  }
+
+  if (net_status.rank >= 0) {
+    if (context_rank >= 0 && net_status.rank != context_rank) {
+      return false;
+    }
+    *failed_rank = net_status.rank;
+    return true;
+  }
+
+  if (context_rank < 0) return false;
+  *failed_rank = context_rank;
+  return true;
+}
+
+static void cleanup_failed_simple_operation(const net_status_t& net_status)
+{
+  if (net_status.user_context == nullptr) return;
 
   internal_context_t* internal_ctx =
       static_cast<internal_context_t*>(net_status.user_context);
-  // Only a one-completion user operation is safe to reclaim here. Extended
-  // contexts cover split/rendezvous protocols, and an empty completion
-  // identifies control or already locally completed operations.
-  if (internal_ctx->is_extended || internal_ctx->comp.is_empty() ||
+  // Extended contexts cover split/rendezvous protocols. Other contexts are
+  // reclaimed only when they belong to a one-completion user operation.
+  if (internal_ctx->is_extended || !internal_ctx->is_user_posted_operation() ||
       internal_ctx->rank < 0) {
-    return false;
+    return;
   }
 
-  const int context_rank = internal_ctx->rank;
   delete internal_ctx;
-  if (net_status.rank >= 0 && net_status.rank != context_rank) {
-    return false;
-  }
-  *failed_rank = context_rank;
-  return true;
 }
 
 void progress_write(endpoint_t endpoint, const net_status_t& net_status)
@@ -243,7 +262,8 @@ void process_completion_batch(runtime_t runtime, device_t device,
     const net_status_t& status = statuses[i];
     if (status.opcode == net_opcode_t::ERROR) {
       int failed_rank = -1;
-      bool has_rank = cleanup_failed_simple_operation(status, &failed_rank);
+      bool has_rank = get_failed_peer_rank(status, &failed_rank);
+      cleanup_failed_simple_operation(status);
       if (!has_failure) {
         has_failure = true;
         first_failure_has_rank = has_rank;

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -97,8 +97,7 @@ void progress_send(const net_status_t& net_status)
   free_ctx_and_signal_comp(internal_ctx);
 }
 
-static bool get_failed_peer_rank(const net_status_t& net_status,
-                                 int* failed_rank)
+static int get_failed_peer_rank(const net_status_t& net_status)
 {
   // Extract peer identity before cleanup. A rank is still useful diagnostic
   // information when the operation did not request a completion object.
@@ -111,17 +110,12 @@ static bool get_failed_peer_rank(const net_status_t& net_status,
     }
   }
 
-  if (net_status.rank >= 0) {
-    if (context_rank >= 0 && net_status.rank != context_rank) {
-      return false;
-    }
-    *failed_rank = net_status.rank;
-    return true;
+  if (net_status.rank >= 0 && context_rank >= 0 &&
+      net_status.rank != context_rank) {
+    return -1;
   }
 
-  if (context_rank < 0) return false;
-  *failed_rank = context_rank;
-  return true;
+  return net_status.rank >= 0 ? net_status.rank : context_rank;
 }
 
 static void cleanup_failed_simple_operation(const net_status_t& net_status)
@@ -261,12 +255,11 @@ void process_completion_batch(runtime_t runtime, device_t device,
   for (size_t i = 0; i < count; i++) {
     const net_status_t& status = statuses[i];
     if (status.opcode == net_opcode_t::ERROR) {
-      int failed_rank = -1;
-      bool has_rank = get_failed_peer_rank(status, &failed_rank);
+      const int failed_rank = get_failed_peer_rank(status);
       cleanup_failed_simple_operation(status);
       if (!has_failure) {
         has_failure = true;
-        first_failure_has_rank = has_rank;
+        first_failure_has_rank = failed_rank >= 0;
         first_failed_rank = failed_rank;
       }
     } else if (status.opcode == net_opcode_t::RECV) {

--- a/src/core/protocol.hpp
+++ b/src/core/protocol.hpp
@@ -70,6 +70,8 @@ struct alignas(LCI_CACHE_LINE) internal_context_t {
     endpoint.get_impl()->add_pending_ops();
   }
 
+  bool is_user_posted_operation() const { return is_user_posted_op; }
+
   void set_mr_on_the_fly(mr_t mr_)
   {
     mr_on_the_fly = true;

--- a/tests/unit/cxx11/run_tcp_pmi_test.sh
+++ b/tests/unit/cxx11/run_tcp_pmi_test.sh
@@ -6,20 +6,35 @@ nranks=${2:-2}
 mode=${3:-pmi}
 endpoint_prefix=${4:-LCT}
 
-port=$(python3 - <<'PY'
+choose_port() {
+  python3 - <<'PY'
 import socket
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.bind(("127.0.0.1", 0))
+
+try:
+    s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    except OSError:
+        pass
+    s.bind(("::", 0))
+except OSError:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", 0))
+
 print(s.getsockname()[1])
 s.close()
 PY
-)
+}
+
 logdir=$(mktemp -d "${TMPDIR:-/tmp}/lct-tcp-pmi.XXXXXX")
 status=0
 expect_failure=0
 expected_failure_pattern=
 reject_torchrun_backend=0
 pids=()
+port=
 
 cleanup() {
   for pid in "${pids[@]:-}"; do
@@ -72,6 +87,42 @@ set_endpoint_env() {
   esac
 }
 
+launch_rank() {
+  local rank=$1
+  (
+    unset LCT_PMI_BACKEND
+    if [[ $reject_torchrun_backend -eq 1 ]]; then
+      export LCT_PMI_BACKEND=torchrun
+    elif [[ "$mode" != "fallback-local" ]]; then
+      export LCT_PMI_BACKEND=tcp
+    fi
+    export RANK=$rank
+    export WORLD_SIZE=$nranks
+    export LOCAL_RANK=$rank
+    export LOCAL_WORLD_SIZE=$nranks
+    export LCT_PMI_TCP_TIMEOUT_SEC=10
+    export LCI_ENABLE_BOOTSTRAP_LCI=0
+    set_endpoint_env
+    exec "$exe" "$mode"
+  ) >"$logdir/rank-$rank.log" 2>&1 &
+  pids+=("$!")
+}
+
+launch_ranks() {
+  for rank in $(seq 0 $((nranks - 1))); do
+    launch_rank "$rank"
+  done
+}
+
+wait_for_ranks() {
+  status=0
+  for pid in "${pids[@]}"; do
+    if ! wait "$pid"; then
+      status=1
+    fi
+  done
+}
+
 case "$mode" in
   pmi|runtime)
     ;;
@@ -98,31 +149,33 @@ case "$mode" in
     ;;
 esac
 
-for rank in $(seq 0 $((nranks - 1))); do
-  (
-    unset LCT_PMI_BACKEND
-    if [[ $reject_torchrun_backend -eq 1 ]]; then
-      export LCT_PMI_BACKEND=torchrun
-    elif [[ "$mode" != "fallback-local" ]]; then
-      export LCT_PMI_BACKEND=tcp
-    fi
-    export RANK=$rank
-    export WORLD_SIZE=$nranks
-    export LOCAL_RANK=$rank
-    export LOCAL_WORLD_SIZE=$nranks
-    export LCT_PMI_TCP_TIMEOUT_SEC=10
-    export LCI_ENABLE_BOOTSTRAP_LCI=0
-    set_endpoint_env
-    exec "$exe" "$mode"
-  ) >"$logdir/rank-$rank.log" 2>&1 &
-  pids+=("$!")
-done
+if [[ $expect_failure -eq 0 && "$mode" != "fallback-local" &&
+      $nranks -gt 1 ]]; then
+  max_port_attempts=5
+  for attempt in $(seq 1 "$max_port_attempts"); do
+    port=$(choose_port)
+    pids=()
+    launch_ranks
+    wait_for_ranks
 
-for pid in "${pids[@]}"; do
-  if ! wait "$pid"; then
-    status=1
-  fi
-done
+    if [[ $status -eq 0 ]]; then
+      break
+    fi
+    if [[ ! -f "$logdir/rank-0.log" ]] ||
+       ! grep -q "Address already in use" "$logdir/rank-0.log"; then
+      break
+    fi
+
+    if [[ $attempt -lt $max_port_attempts ]]; then
+      echo "TCP PMI port $port was claimed before rank 0 started; retrying" >&2
+      rm -f "$logdir"/*.log
+    fi
+  done
+else
+  port=$(choose_port)
+  launch_ranks
+  wait_for_ranks
+fi
 
 if [[ $expect_failure -eq 1 ]]; then
   if [[ $status -ne 0 ]]; then

--- a/tests/unit/cxx11/run_tcp_pmi_test.sh
+++ b/tests/unit/cxx11/run_tcp_pmi_test.sh
@@ -6,35 +6,20 @@ nranks=${2:-2}
 mode=${3:-pmi}
 endpoint_prefix=${4:-LCT}
 
-choose_port() {
-  python3 - <<'PY'
+port=$(python3 - <<'PY'
 import socket
-
-try:
-    s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    try:
-        s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-    except OSError:
-        pass
-    s.bind(("::", 0))
-except OSError:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(("0.0.0.0", 0))
-
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.bind(("127.0.0.1", 0))
 print(s.getsockname()[1])
 s.close()
 PY
-}
-
+)
 logdir=$(mktemp -d "${TMPDIR:-/tmp}/lct-tcp-pmi.XXXXXX")
 status=0
 expect_failure=0
 expected_failure_pattern=
 reject_torchrun_backend=0
 pids=()
-port=
 
 cleanup() {
   for pid in "${pids[@]:-}"; do
@@ -87,42 +72,6 @@ set_endpoint_env() {
   esac
 }
 
-launch_rank() {
-  local rank=$1
-  (
-    unset LCT_PMI_BACKEND
-    if [[ $reject_torchrun_backend -eq 1 ]]; then
-      export LCT_PMI_BACKEND=torchrun
-    elif [[ "$mode" != "fallback-local" ]]; then
-      export LCT_PMI_BACKEND=tcp
-    fi
-    export RANK=$rank
-    export WORLD_SIZE=$nranks
-    export LOCAL_RANK=$rank
-    export LOCAL_WORLD_SIZE=$nranks
-    export LCT_PMI_TCP_TIMEOUT_SEC=10
-    export LCI_ENABLE_BOOTSTRAP_LCI=0
-    set_endpoint_env
-    exec "$exe" "$mode"
-  ) >"$logdir/rank-$rank.log" 2>&1 &
-  pids+=("$!")
-}
-
-launch_ranks() {
-  for rank in $(seq 0 $((nranks - 1))); do
-    launch_rank "$rank"
-  done
-}
-
-wait_for_ranks() {
-  status=0
-  for pid in "${pids[@]}"; do
-    if ! wait "$pid"; then
-      status=1
-    fi
-  done
-}
-
 case "$mode" in
   pmi|runtime)
     ;;
@@ -149,33 +98,31 @@ case "$mode" in
     ;;
 esac
 
-if [[ $expect_failure -eq 0 && "$mode" != "fallback-local" &&
-      $nranks -gt 1 ]]; then
-  max_port_attempts=5
-  for attempt in $(seq 1 "$max_port_attempts"); do
-    port=$(choose_port)
-    pids=()
-    launch_ranks
-    wait_for_ranks
+for rank in $(seq 0 $((nranks - 1))); do
+  (
+    unset LCT_PMI_BACKEND
+    if [[ $reject_torchrun_backend -eq 1 ]]; then
+      export LCT_PMI_BACKEND=torchrun
+    elif [[ "$mode" != "fallback-local" ]]; then
+      export LCT_PMI_BACKEND=tcp
+    fi
+    export RANK=$rank
+    export WORLD_SIZE=$nranks
+    export LOCAL_RANK=$rank
+    export LOCAL_WORLD_SIZE=$nranks
+    export LCT_PMI_TCP_TIMEOUT_SEC=10
+    export LCI_ENABLE_BOOTSTRAP_LCI=0
+    set_endpoint_env
+    exec "$exe" "$mode"
+  ) >"$logdir/rank-$rank.log" 2>&1 &
+  pids+=("$!")
+done
 
-    if [[ $status -eq 0 ]]; then
-      break
-    fi
-    if [[ ! -f "$logdir/rank-0.log" ]] ||
-       ! grep -q "Address already in use" "$logdir/rank-0.log"; then
-      break
-    fi
-
-    if [[ $attempt -lt $max_port_attempts ]]; then
-      echo "TCP PMI port $port was claimed before rank 0 started; retrying" >&2
-      rm -f "$logdir"/*.log
-    fi
-  done
-else
-  port=$(choose_port)
-  launch_ranks
-  wait_for_ranks
-fi
+for pid in "${pids[@]}"; do
+  if ! wait "$pid"; then
+    status=1
+  fi
+done
 
 if [[ $expect_failure -eq 1 ]]; then
   if [[ $status -ne 0 ]]; then

--- a/tests/unit/loopback/test_network.hpp
+++ b/tests/unit/loopback/test_network.hpp
@@ -97,6 +97,61 @@ TEST(NETWORK, completion_batch_first_generic_failure_wins)
   lci::g_runtime_fina();
 }
 
+TEST(NETWORK, completion_batch_reports_rank_without_completion_object)
+{
+  lci::g_runtime_init();
+  lci::runtime_t runtime = lci::g_default_runtime;
+  lci::device_t device = lci::get_default_device();
+  lci::endpoint_t endpoint = lci::get_default_endpoint();
+  const int64_t initial_pending = endpoint.get_impl()->get_pending_ops();
+
+  for (int backend_rank : {7, -1}) {
+    auto* context = new lci::internal_context_t;
+    context->set_user_posted_op(endpoint);
+    context->rank = 7;
+    EXPECT_TRUE(context->comp.is_empty());
+
+    lci::net_status_t status = {};
+    status.opcode = lci::net_opcode_t::ERROR;
+    status.rank = backend_rank;
+    status.user_context = context;
+
+    try {
+      lci::process_completion_batch(runtime, device, endpoint, &status, 1);
+      FAIL() << "Expected peer_failure_error";
+    } catch (const lci::peer_failure_error& error) {
+      EXPECT_EQ(error.failed_rank(), 7);
+    }
+
+    EXPECT_EQ(endpoint.get_impl()->get_pending_ops(), initial_pending);
+  }
+
+  lci::g_runtime_fina();
+}
+
+TEST(NETWORK, completion_batch_unknown_rank_is_generic)
+{
+  lci::g_runtime_init();
+  lci::runtime_t runtime = lci::g_default_runtime;
+  lci::device_t device = lci::get_default_device();
+  lci::endpoint_t endpoint = lci::get_default_endpoint();
+
+  lci::net_status_t status = {};
+  status.opcode = lci::net_opcode_t::ERROR;
+  status.rank = -1;
+  status.user_context = nullptr;
+
+  try {
+    lci::process_completion_batch(runtime, device, endpoint, &status, 1);
+    FAIL() << "Expected generic runtime_error";
+  } catch (const lci::peer_failure_error&) {
+    FAIL() << "An unknown rank must not report peer_failure_error";
+  } catch (const std::runtime_error&) {
+  }
+
+  lci::g_runtime_fina();
+}
+
 TEST(NETWORK, reg_mem)
 {
   lci::g_runtime_init();


### PR DESCRIPTION
## Summary

- Split failed-peer rank extraction from failed-operation cleanup.
- Preserve peer-rank reporting when an AM uses `lci::COMP_NULL`.
- Reclaim non-extended, user-posted failed contexts regardless of whether they requested a completion object.
- Add loopback coverage for empty-completion rank reporting and unknown-rank fallback behavior.

## Validation

- `NETWORK.completion_batch_*` (4 tests)
- `ctest -R '^(test-loopback-all|test-resilience-process-failure)$'`
- Native IBV two-rank AM reproduction on `banff20-05`: after killing rank 1, a `COMP_NULL` AM now throws `peer_failure_error` with `failed_rank() == 1`.

Fixes #182
