### PR TITLE
Reclaim posted receive packets on device free

### DIFF
--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -245,9 +245,8 @@ void progress_read(const net_status_t& net_status)
   }
 }
 
-void process_completion_batch(runtime_t runtime, device_t device,
-                              endpoint_t endpoint, const net_status_t* statuses,
-                              size_t count)
+void process_completion_batch(runtime_t runtime, device_t, endpoint_t endpoint,
+                              const net_status_t* statuses, size_t count)
 {
   bool has_failure = false;
   bool first_failure_has_rank = false;
@@ -263,7 +262,6 @@ void process_completion_batch(runtime_t runtime, device_t device,
         first_failed_rank = failed_rank;
       }
     } else if (status.opcode == net_opcode_t::RECV) {
-      device.p_impl->consume_recvs(1);
       progress_recv(runtime, endpoint, status);
     } else if (status.opcode == net_opcode_t::SEND) {
       progress_send(status);

--- a/src/network/device_inline.hpp
+++ b/src/network/device_inline.hpp
@@ -97,54 +97,89 @@ inline void device_impl_t::destroy_reg_cache()
   }
 }
 
+inline void device_impl_t::release_posted_recv_slot(packet_t* packet)
+{
+  const size_t slot = packet->local_context.posted_recv_slot;
+  LCI_Assert(slot != PACKET_POSTED_RECV_SLOT_INVALID &&
+                 slot < posted_recvs.size() && posted_recvs[slot] == packet,
+             "Invalid posted receive slot\n");
+  posted_recvs[slot] = nullptr;
+  free_posted_recv_slots.push_back(slot);
+  packet->local_context.posted_recv_slot = PACKET_POSTED_RECV_SLOT_INVALID;
+}
+
+inline packet_t* device_impl_t::complete_recv(void* user_context)
+{
+  std::lock_guard<spinlock_t> lock(posted_recvs_lock);
+  if (!packet_pool.p_impl ||
+      !packet_pool.p_impl->is_packet(user_context, true)) {
+    return nullptr;
+  }
+
+  packet_t* packet = static_cast<packet_t*>(user_context);
+  const size_t slot = packet->local_context.posted_recv_slot;
+  if (slot == PACKET_POSTED_RECV_SLOT_INVALID || slot >= posted_recvs.size() ||
+      posted_recvs[slot] != packet) {
+    return nullptr;
+  }
+
+  release_posted_recv_slot(packet);
+  const size_t previous = nrecvs_posted.fetch_sub(1, std::memory_order_relaxed);
+  LCI_Assert(previous > 0, "Posted receive count underflow\n");
+  return packet;
+}
+
 inline bool device_impl_t::post_recv_packets()
 {
-  mr_t mr;
-  size_t size;
-  error_t error;
-  if (nrecvs_posted >= attr.net_max_recvs) {
-    return false;
-  }
   const size_t BATCH_SIZE = LCI_BACKEND_MAX_POLLS * 2;
+  packet_t* packets[BATCH_SIZE];
+  void* buffers[BATCH_SIZE];
 
-  size_t my_position = nrecvs_posted.fetch_add(BATCH_SIZE);
-
-  if (my_position >= attr.net_max_recvs) {
-    nrecvs_posted -= BATCH_SIZE;
+  std::lock_guard<spinlock_t> lock(posted_recvs_lock);
+  if (posted_recvs_stopping || !packet_pool.p_impl ||
+      free_posted_recv_slots.empty()) {
     return false;
   }
-  size_t nslots = std::min(attr.net_max_recvs - my_position, BATCH_SIZE);
-  packet_t* packets[BATCH_SIZE];
 
+  const size_t nslots = std::min(BATCH_SIZE, free_posted_recv_slots.size());
   size_t n_popped = packet_pool.p_impl->get_n(nslots, packets, false);
   if (n_popped == 0) {
-    nrecvs_posted -= BATCH_SIZE;
     return false;
   }
 
-  mr = packet_pool.p_impl->get_or_register_mr(device);
-  size = packet_pool.p_impl->get_payload_size();
-  void* buffers[BATCH_SIZE];
   for (size_t i = 0; i < n_popped; i++) {
     buffers[i] = packets[i]->get_payload_address();
+    const size_t slot = free_posted_recv_slots.back();
+    free_posted_recv_slots.pop_back();
+    posted_recvs[slot] = packets[i];
+    packets[i]->local_context.posted_recv_slot = slot;
   }
+
+  mr_t mr = packet_pool.p_impl->get_or_register_mr(device);
+  size_t size = packet_pool.p_impl->get_payload_size();
   size_t n_posted =
       post_recvs((void**)buffers, size, n_popped, mr, (void**)packets);
+  LCI_Assert(n_posted <= n_popped,
+             "Backend posted more receives than requested\n");
   for (size_t i = n_posted; i < n_popped; i++) {
+    release_posted_recv_slot(packets[i]);
     packets[i]->put_back();
   }
-  if (BATCH_SIZE != n_posted) {
-    nrecvs_posted -= (BATCH_SIZE - n_posted);
+  if (n_posted > 0) {
+    nrecvs_posted.fetch_add(n_posted, std::memory_order_relaxed);
   }
   return n_posted > 0;
 }
 
 inline bool device_impl_t::refill_recvs(bool is_blocking)
 {
+  if (!packet_pool.p_impl) {
+    return false;
+  }
   const double refill_threshold = 0.8;
   const int max_retries = 100000;
   bool ret = false;
-  int nrecvs_posted = this->nrecvs_posted;
+  size_t nrecvs_posted = this->nrecvs_posted;
   int niters = 0;
   while (nrecvs_posted < attr.net_max_recvs * refill_threshold) {
     bool succeed = post_recv_packets();
@@ -154,7 +189,7 @@ inline bool device_impl_t::refill_recvs(bool is_blocking)
         if (niters > max_retries) {
           LCI_Warn(
               "Deadlock alert! The device failed to refill the recvs to the "
-              "maximum (current %d)\n",
+              "maximum (current %lu)\n",
               nrecvs_posted);
           break;
         }
@@ -179,17 +214,54 @@ inline bool device_impl_t::refill_recvs(bool is_blocking)
 
 inline void device_impl_t::bind_packet_pool(packet_pool_t packet_pool_)
 {
-  packet_pool = packet_pool_;
+  {
+    std::lock_guard<spinlock_t> lock(posted_recvs_lock);
+    LCI_Assert(!packet_pool.p_impl, "A packet pool is already bound\n");
+    packet_pool = packet_pool_;
+    posted_recvs.assign(attr.net_max_recvs, nullptr);
+    free_posted_recv_slots.clear();
+    free_posted_recv_slots.reserve(attr.net_max_recvs);
+    for (size_t i = attr.net_max_recvs; i > 0; --i) {
+      free_posted_recv_slots.push_back(i - 1);
+    }
+    posted_recvs_stopping = false;
+    nrecvs_posted.store(0, std::memory_order_relaxed);
+  }
   packet_pool.p_impl->register_packets(device);
   refill_recvs(true);
 }
 
 inline void device_impl_t::unbind_packet_pool()
 {
-  // if we have been using packet pool, report lost packets
-  if (packet_pool.p_impl) {
-    packet_pool.p_impl->deregister_packets(device);
-    packet_pool.p_impl->report_lost_packets(nrecvs_posted);
+  packet_pool_impl_t* p_packet_pool = nullptr;
+  std::vector<packet_t*> posted_recvs_snapshot;
+  {
+    std::lock_guard<spinlock_t> lock(posted_recvs_lock);
+    if (!packet_pool.p_impl) {
+      return;
+    }
+    posted_recvs_stopping = true;
+    p_packet_pool = packet_pool.p_impl;
+    posted_recvs_snapshot = posted_recvs;
+  }
+
+  // The endpoint resources that can still reference these packets must be
+  // retired before their MR is closed or the packets are returned to the pool.
+  quiesce_recvs_impl(posted_recvs_snapshot);
+  p_packet_pool->deregister_packets(device);
+
+  {
+    std::lock_guard<spinlock_t> lock(posted_recvs_lock);
+    for (packet_t* packet : posted_recvs) {
+      if (packet != nullptr) {
+        packet->local_context.posted_recv_slot =
+            PACKET_POSTED_RECV_SLOT_INVALID;
+        packet->put_back();
+      }
+    }
+    posted_recvs.clear();
+    free_posted_recv_slots.clear();
+    nrecvs_posted.store(0, std::memory_order_relaxed);
     packet_pool.p_impl = nullptr;
   }
 }

--- a/src/network/ibv/backend_ibv.cpp
+++ b/src/network/ibv/backend_ibv.cpp
@@ -240,8 +240,27 @@ ibv_device_impl_t::~ibv_device_impl_t()
     IBV_SAFECALL(ibv_dealloc_td(ib_td));
     --g_td_num;
   }
-  IBV_SAFECALL(ibv_destroy_cq(ib_cq));
-  IBV_SAFECALL(ibv_destroy_srq(ib_srq));
+  if (ib_srq) {
+    IBV_SAFECALL(ibv_destroy_srq(ib_srq));
+  }
+  if (ib_cq) {
+    IBV_SAFECALL(ibv_destroy_cq(ib_cq));
+  }
+}
+
+void ibv_device_impl_t::quiesce_recvs_impl(const std::vector<packet_t*>&)
+{
+  // All QPs that use this SRQ have been destroyed by device teardown before
+  // this hook runs. Retiring the SRQ drops its receive WQEs; retiring the CQ
+  // then prevents any remaining completion from referencing their wr_id.
+  if (ib_srq) {
+    IBV_SAFECALL(ibv_destroy_srq(ib_srq));
+    ib_srq = nullptr;
+  }
+  if (ib_cq) {
+    IBV_SAFECALL(ibv_destroy_cq(ib_cq));
+    ib_cq = nullptr;
+  }
 }
 
 endpoint_t ibv_device_impl_t::alloc_endpoint_impl(endpoint_t::attr_t attr)

--- a/src/network/ibv/backend_ibv.hpp
+++ b/src/network/ibv/backend_ibv.hpp
@@ -121,6 +121,7 @@ class ibv_device_impl_t : public lci::device_impl_t
                          void* user_context) override;
   size_t post_recvs_impl(void* buffers[], size_t size, size_t count, mr_t mrm,
                          void* usesr_contexts[]) override;
+  void quiesce_recvs_impl(const std::vector<packet_t*>& posted_recvs) override;
 
   // Connections O(N)
   struct ibv_td* ib_td;

--- a/src/network/ibv/backend_ibv_inline.hpp
+++ b/src/network/ibv/backend_ibv_inline.hpp
@@ -119,6 +119,11 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       qp2rank_map_t::entry_t entry = snapshot->get_entry(wcs[i].qp_num);
       const bool is_receive = wcs[i].opcode == IBV_WC_RECV ||
                               wcs[i].opcode == IBV_WC_RECV_RDMA_WITH_IMM;
+      packet_t* completed_recv =
+          is_receive ? complete_recv((void*)wcs[i].wr_id) : nullptr;
+      if (wcs[i].status != IBV_WC_SUCCESS && completed_recv != nullptr) {
+        completed_recv->put_back();
+      }
       // A failed send-side completion still releases its SQ slot.
       if (!is_receive) {
         if (entry.rank >= 0 && entry.rank < get_rank_n() &&
@@ -149,7 +154,6 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
         status.imm_data = wcs[i].imm_data;
         status.rank = entry.rank;
       } else if (wcs[i].opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
-        consume_recvs(1);
         status.opcode = net_opcode_t::REMOTE_WRITE;
         status.user_context = (void*)wcs[i].wr_id;
         status.imm_data = wcs[i].imm_data;

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -4,8 +4,13 @@
 #ifndef LCI_NETWORK_HPP
 #define LCI_NETWORK_HPP
 
+#include <mutex>
+#include <vector>
+
 namespace lci
 {
+struct packet_t;
+
 class net_context_impl_t
 {
  public:
@@ -38,6 +43,8 @@ class device_impl_t
                                  void* user_context) = 0;
   virtual size_t post_recvs_impl(void* buffers[], size_t size, size_t count,
                                  mr_t mr, void* usesr_contexts[]) = 0;
+  virtual void quiesce_recvs_impl(
+      const std::vector<packet_t*>& posted_recvs) = 0;
 
   // wrapper functions
   endpoint_t alloc_endpoint(endpoint_t::attr_t attr);
@@ -56,7 +63,7 @@ class device_impl_t
   inline void unbind_packet_pool();
   inline bool post_recv_packets();
   inline bool refill_recvs(bool is_blocking = false);
-  inline void consume_recvs(int n) { nrecvs_posted -= n; }
+  inline packet_t* complete_recv(void* user_context);
   static int reserve_device_ids(int n)
   {
     return g_ndevices.fetch_add(n, std::memory_order_relaxed);
@@ -81,10 +88,16 @@ class device_impl_t
   RegCache* rcache_handle = nullptr;
 
  private:
+  inline void release_posted_recv_slot(packet_t* packet);
+
   static std::atomic<int> g_ndevices;
   LCIU_CACHE_PADDING(sizeof(std::atomic<int>));
   std::atomic<size_t> nrecvs_posted;
   LCIU_CACHE_PADDING(sizeof(std::atomic<size_t>));
+  std::vector<packet_t*> posted_recvs;
+  std::vector<size_t> free_posted_recv_slots;
+  bool posted_recvs_stopping = false;
+  spinlock_t posted_recvs_lock;
 };
 
 class mr_impl_t

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -52,6 +52,17 @@ struct fi_info* select_info(struct fi_info* ofi_info,
   }
   return first_match;
 }
+
+bool remove_pending_recv(std::vector<void*>& pending_recvs, void* context)
+{
+  auto it = std::find(pending_recvs.begin(), pending_recvs.end(), context);
+  if (it == pending_recvs.end()) {
+    return false;
+  }
+  *it = pending_recvs.back();
+  pending_recvs.pop_back();
+  return true;
+}
 }  // namespace
 
 bool ofi_net_context_impl_t::check_availability()
@@ -325,6 +336,93 @@ ofi_device_impl_t::~ofi_device_impl_t()
   FI_SAFECALL(fi_close((struct fid*)&ofi_cq->fid));
   FI_SAFECALL(fi_close((struct fid*)&ofi_av->fid));
   FI_SAFECALL(fi_close((struct fid*)&ofi_domain->fid));
+}
+
+void ofi_device_impl_t::quiesce_recvs_impl(
+    const std::vector<packet_t*>& posted_recvs)
+{
+  std::vector<void*> pending_recvs;
+  pending_recvs.reserve(posted_recvs.size());
+  for (packet_t* packet : posted_recvs) {
+    if (packet != nullptr) {
+      pending_recvs.push_back(packet);
+    }
+  }
+  if (pending_recvs.empty()) {
+    return;
+  }
+
+  // Serialize with configured OFI receive and polling paths while cancellation
+  // requests and their terminal CQ entries are driven to completion.
+  std::lock_guard<spinlock_t> lock_guard(lock);
+  auto drain_cq = [&]() {
+    struct fi_cq_data_entry entries[LCI_BACKEND_MAX_POLLS];
+    ssize_t nentries = fi_cq_read(ofi_cq, entries, LCI_BACKEND_MAX_POLLS);
+    if (nentries > 0) {
+      for (ssize_t i = 0; i < nentries; ++i) {
+        if (entries[i].flags & FI_RECV) {
+          remove_pending_recv(pending_recvs, entries[i].op_context);
+        }
+      }
+      return;
+    }
+    if (nentries == 0 || nentries == -FI_EAGAIN) {
+      return;
+    }
+
+    LCI_Assert(nentries == -FI_EAVAIL,
+               "fi_cq_read during receive teardown failed: %s\n",
+               fi_strerror(-nentries));
+    struct fi_cq_err_entry error = {};
+    char err_data[64];
+    error.err_data = err_data;
+    error.err_data_size = sizeof(err_data);
+    ssize_t ret = fi_cq_readerr(ofi_cq, &error, 0);
+    if (ret == -FI_EAGAIN) {
+      return;
+    }
+    LCI_Assert(ret == 1, "fi_cq_readerr during receive teardown failed: %s\n",
+               fi_strerror(-ret));
+    if (error.flags & FI_RECV) {
+      remove_pending_recv(pending_recvs, error.op_context);
+    }
+  };
+
+  const std::vector<void*> recv_contexts = pending_recvs;
+  for (void* context : recv_contexts) {
+    if (std::find(pending_recvs.begin(), pending_recvs.end(), context) ==
+        pending_recvs.end()) {
+      continue;
+    }
+    for (;;) {
+      ssize_t ret = fi_cancel(&ofi_ep->fid, context);
+      if (ret == FI_SUCCESS || ret == -FI_ENOENT) {
+        break;
+      }
+      if (ret == -FI_EAGAIN) {
+        drain_cq();
+        if (std::find(pending_recvs.begin(), pending_recvs.end(), context) ==
+            pending_recvs.end()) {
+          break;
+        }
+        continue;
+      }
+      if (ret == -FI_ENOSYS || ret == -FI_EOPNOTSUPP) {
+        LCI_Assert(
+            false,
+            "The OFI provider cannot cancel posted receives; refusing to "
+            "deregister or reclaim packet-pool memory unsafely\n");
+      }
+      FI_SAFECALL(ret);
+    }
+  }
+
+  // A receive can race its cancellation and appear as a normal CQ entry.
+  // Do not close the endpoint-bound MR until each tracked context has a
+  // terminal receive completion or error completion.
+  while (!pending_recvs.empty()) {
+    drain_cq();
+  }
 }
 
 endpoint_t ofi_device_impl_t::alloc_endpoint_impl(endpoint_t::attr_t attr)

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -97,6 +97,7 @@ class ofi_device_impl_t : public lci::device_impl_t
                          void* user_context) override;
   size_t post_recvs_impl(void* buffers[], size_t size, size_t count, mr_t mr,
                          void* usesr_contexts[]) override;
+  void quiesce_recvs_impl(const std::vector<packet_t*>& posted_recvs) override;
 
   struct fi_domain_attr* ofi_domain_attr;
   struct fid_domain* ofi_domain;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -16,6 +16,9 @@ inline size_t ofi_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
                                                 size_t max_polls)
 {
   struct fi_cq_data_entry fi_entries[LCI_BACKEND_MAX_POLLS];
+  struct fi_cq_err_entry error = {};
+  char err_data[64];
+  bool has_error = false;
 
   // Keep the configured polling lock across both reads so another poller
   // cannot consume the error entry reported by fi_cq_read.
@@ -25,62 +28,76 @@ inline size_t ofi_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
   }
 
   ssize_t ne = fi_cq_read(ofi_cq, fi_entries, max_polls);
-  if (ne > 0) {
-    // Got an entry here
-    for (int j = 0; j < ne; j++) {
-      if (p_statuses) {
-        net_status_t& status = p_statuses[j];
-        memset(&status, 0, sizeof(status));
-        if (fi_entries[j].flags & FI_RECV) {
-          status.opcode = net_opcode_t::RECV;
-          status.user_context = fi_entries[j].op_context;
-          status.length = fi_entries[j].len;
-          status.imm_data = fi_entries[j].data & ((1ULL << 32) - 1);
-          status.rank = (int)(fi_entries[j].data >> 32);
-        } else if (fi_entries[j].flags & FI_REMOTE_WRITE) {
-          status.opcode = net_opcode_t::REMOTE_WRITE;
-          status.user_context = NULL;
-          status.imm_data = fi_entries[j].data;
-        } else if (fi_entries[j].flags & FI_SEND) {
-          status.opcode = net_opcode_t::SEND;
-          status.user_context = fi_entries[j].op_context;
-        } else if (fi_entries[j].flags & FI_WRITE) {
-          status.opcode = net_opcode_t::WRITE;
-          status.user_context = fi_entries[j].op_context;
-        } else {
-          LCI_DBG_Assert(fi_entries[j].flags & FI_READ,
-                         "Unexpected OFI opcode!\n");
-          status.opcode = net_opcode_t::READ;
-          status.user_context = fi_entries[j].op_context;
-        }
-      }
-    }
-  } else if (ne == -FI_EAGAIN) {
-    ne = 0;
-  } else {
-    LCI_Assert(ne == -FI_EAVAIL, "unexpected return error: %s\n",
-               fi_strerror(-ne));
-    struct fi_cq_err_entry error = {};
-    char err_data[64];
+  if (ne == -FI_EAGAIN) {
+    return 0;
+  }
+  if (ne == -FI_EAVAIL) {
     error.err_data = err_data;
     error.err_data_size = sizeof(err_data);
     ssize_t ret_cqerr = fi_cq_readerr(ofi_cq, &error, 0);
     if (ret_cqerr == -FI_EAGAIN) {
       return 0;
-    } else {
-      LCI_Assert(ret_cqerr == 1, "fi_cq_readerr failed: %s\n",
-                 fi_strerror(-ret_cqerr));
-      if (p_statuses) {
-        net_status_t& status = p_statuses[0];
-        memset(&status, 0, sizeof(status));
-        status.opcode = net_opcode_t::ERROR;
-        status.rank = -1;
-        const bool is_outgoing =
-            (error.flags & (FI_SEND | FI_WRITE | FI_READ)) != 0 &&
-            (error.flags & (FI_RECV | FI_REMOTE_WRITE)) == 0;
-        status.user_context = is_outgoing ? error.op_context : nullptr;
+    }
+    LCI_Assert(ret_cqerr == 1, "fi_cq_readerr failed: %s\n",
+               fi_strerror(-ret_cqerr));
+    has_error = true;
+  } else {
+    LCI_Assert(ne >= 0, "unexpected return error: %s\n", fi_strerror(-ne));
+  }
+
+  if (poll_lock.owns_lock()) {
+    poll_lock.unlock();
+  }
+
+  if (has_error) {
+    if (error.flags & FI_RECV) {
+      packet_t* packet = complete_recv(error.op_context);
+      if (packet != nullptr) {
+        packet->put_back();
       }
-      ne = 1;
+    }
+    if (p_statuses) {
+      net_status_t& status = p_statuses[0];
+      memset(&status, 0, sizeof(status));
+      status.opcode = net_opcode_t::ERROR;
+      status.rank = -1;
+      const bool is_outgoing =
+          (error.flags & (FI_SEND | FI_WRITE | FI_READ)) != 0 &&
+          (error.flags & (FI_RECV | FI_REMOTE_WRITE)) == 0;
+      status.user_context = is_outgoing ? error.op_context : nullptr;
+    }
+    return 1;
+  }
+
+  for (int j = 0; j < ne; j++) {
+    if (fi_entries[j].flags & FI_RECV) {
+      complete_recv(fi_entries[j].op_context);
+    }
+    if (p_statuses) {
+      net_status_t& status = p_statuses[j];
+      memset(&status, 0, sizeof(status));
+      if (fi_entries[j].flags & FI_RECV) {
+        status.opcode = net_opcode_t::RECV;
+        status.user_context = fi_entries[j].op_context;
+        status.length = fi_entries[j].len;
+        status.imm_data = fi_entries[j].data & ((1ULL << 32) - 1);
+        status.rank = (int)(fi_entries[j].data >> 32);
+      } else if (fi_entries[j].flags & FI_REMOTE_WRITE) {
+        status.opcode = net_opcode_t::REMOTE_WRITE;
+        status.user_context = NULL;
+        status.imm_data = fi_entries[j].data;
+      } else if (fi_entries[j].flags & FI_SEND) {
+        status.opcode = net_opcode_t::SEND;
+        status.user_context = fi_entries[j].op_context;
+      } else if (fi_entries[j].flags & FI_WRITE) {
+        status.opcode = net_opcode_t::WRITE;
+        status.user_context = fi_entries[j].op_context;
+      } else {
+        LCI_DBG_Assert(fi_entries[j].flags & FI_READ,
+                       "Unexpected OFI opcode!\n");
+        status.opcode = net_opcode_t::READ;
+        status.user_context = fi_entries[j].op_context;
+      }
     }
   }
   return static_cast<size_t>(ne);

--- a/src/packet_pool/packet.hpp
+++ b/src/packet_pool/packet.hpp
@@ -7,6 +7,7 @@
 namespace lci
 {
 const int POOLID_LOCAL = -1;
+constexpr size_t PACKET_POSTED_RECV_SLOT_INVALID = static_cast<size_t>(-1);
 
 struct packet_local_context_t {
   packet_pool_impl_t*
@@ -14,6 +15,7 @@ struct packet_local_context_t {
   int local_id : 31;    /* id of the local pool to return this packet */
   bool isInPool : 1;    /* Debug use only. Whether this packet is in the packet
                            pool */
+  size_t posted_recv_slot;
   // context of the ongoing communication
   bool is_eager : 1; /* whether this packet is used for eager protocol */
   int rank;

--- a/src/packet_pool/packet_pool.cpp
+++ b/src/packet_pool/packet_pool.cpp
@@ -12,8 +12,7 @@ packet_pool_impl_t::packet_pool_impl_t(const attr_t& attr_)
       heap(nullptr),
       base_packet_p(nullptr),
       heap_size(0),
-      mrs(64),
-      npacket_lost(0)
+      mrs(64)
 {
   if (attr.npackets > 0) {
     heap_size = attr.npackets * attr.packet_size + LCI_CACHE_LINE;
@@ -38,9 +37,8 @@ packet_pool_impl_t::~packet_pool_impl_t()
 {
   // check whether there are any packets missing
   if (attr.npackets > 0) {
-    size_t total = pool.size() + npacket_lost;
-    if (total != attr.npackets) {
-      LCI_Warn("Lost %d packets\n", attr.npackets - total);
+    if (pool.size() != attr.npackets) {
+      LCI_Warn("Lost %lu packets\n", attr.npackets - pool.size());
     }
   }
   for (size_t i = 0; i < mrs.get_size(); i++) {

--- a/src/packet_pool/packet_pool.hpp
+++ b/src/packet_pool/packet_pool.hpp
@@ -37,8 +37,6 @@ class packet_pool_impl_t
   }
   size_t get_size() const { return pool.size(); }
   int get_local_id() const { return pool.get_local_set_id(); }
-  // Report lost packets
-  void report_lost_packets(int npackets) { npacket_lost += npackets; }
 
   attr_t attr;
 
@@ -48,7 +46,6 @@ class packet_pool_impl_t
   void* base_packet_p;
   size_t heap_size;
   mpmc_array_t<mr_impl_t*> mrs;
-  std::atomic<size_t> npacket_lost;
 };
 
 inline packet_t* packet_pool_impl_t::get(bool blocking)
@@ -78,6 +75,7 @@ inline size_t packet_pool_impl_t::get_n(size_t n, packet_t* buf_out[],
     packet->local_context.packet_pool_impl = this;
     packet->local_context.isInPool = false;
     packet->local_context.local_id = mpmc_set_t::LOCAL_SET_ID_NULL;
+    packet->local_context.posted_recv_slot = PACKET_POSTED_RECV_SLOT_INVALID;
   }
   if (n_popped == 0) {
     LCI_PCOUNTER_ADD(packet_get_retry, 1);
@@ -94,6 +92,9 @@ inline void packet_pool_impl_t::put(packet_t* p_packet)
   packet_t* packet = static_cast<packet_t*>(p_packet);
   LCI_Assert(!packet->local_context.isInPool,
              "This packet has already been freed!\n");
+  LCI_Assert(
+      packet->local_context.posted_recv_slot == PACKET_POSTED_RECV_SLOT_INVALID,
+      "Cannot return a packet while it is posted as a receive\n");
   packet->local_context.isInPool = true;
   pool.put(packet, packet->local_context.local_id);
   LCI_PCOUNTER_ADD(packet_put, 1);

--- a/tests/unit/loopback/test_network.hpp
+++ b/tests/unit/loopback/test_network.hpp
@@ -184,6 +184,50 @@ TEST(NETWORK, poll_cq)
   lci::g_runtime_fina();
 }
 
+TEST(NETWORK, free_device_reclaims_posted_receive_packets)
+{
+  constexpr size_t npackets = 64;
+  constexpr int niterations = 5;
+
+  lci::runtime_t runtime = lci::g_runtime_init_x()
+                               .alloc_default_device(false)
+                               .alloc_default_packet_pool(false)();
+  lci::packet_pool_t packet_pool =
+      lci::alloc_packet_pool_x().runtime(runtime).npackets(npackets)();
+
+  for (int i = 0; i < niterations; ++i) {
+    lci::device_t device = lci::alloc_device_x()
+                               .runtime(runtime)
+                               .packet_pool(packet_pool)
+                               .net_max_recvs(npackets)();
+    lci::free_device_x(&device).runtime(runtime)();
+
+    std::vector<void*> packets;
+    packets.reserve(npackets);
+    for (size_t j = 0; j < npackets; ++j) {
+      void* packet =
+          lci::get_upacket_x().runtime(runtime).packet_pool(packet_pool)();
+      EXPECT_NE(packet, nullptr);
+      if (packet != nullptr) {
+        packets.push_back(packet);
+      }
+    }
+    EXPECT_EQ(packets.size(), npackets);
+    void* extra_packet =
+        lci::get_upacket_x().runtime(runtime).packet_pool(packet_pool)();
+    EXPECT_EQ(extra_packet, nullptr);
+    if (extra_packet != nullptr) {
+      packets.push_back(extra_packet);
+    }
+    for (void* packet : packets) {
+      lci::put_upacket_x(packet).runtime(runtime)();
+    }
+  }
+
+  lci::free_packet_pool_x(&packet_pool).runtime(runtime)();
+  lci::g_runtime_fina();
+}
+
 TEST(NETWORK, loopback)
 {
   // Raw network receives must not compete with LCI's packet-pool receives.


### PR DESCRIPTION
## Summary

- Track the exact packet identities backing LCI-managed posted receives.
- Quiesce receive resources before packet-MR deregistration and pool reuse: SRQ/CQ retirement for IBV, and per-context cancellation/CQ drain for OFI.
- Add a provider-backed repeated device-lifecycle packet-pool regression.

## Validation

- OFI sockets focused lifecycle regression (including `LCI_NET_LOCK_MODE=all`)
- OFI sockets loopback suite
- IBV-only build
- OFI + `LCI_WITH_SHM=ON` build

Fixes #184
