### PR TITLE
Use abortive teardown after network failure

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -74,6 +74,13 @@ recover after catching an exception. `progress()` processes a full batch of
 completed operations before throwing, so successful operations in the same
 batch are still processed.
 
+After an asynchronous network failure is reported, LCI marks the affected
+device as failed. Destroying an endpoint on that device uses abortive teardown:
+it does not wait for outstanding operations that the failed transport may
+never complete. Those operations may be abandoned without signaling their
+completion objects. Normal endpoint teardown still waits for all operations to
+drain when no network failure has been observed.
+
 The `test-resilience-process-failure` CTest program exercises this path with
 the libfabric TCP provider: it kills rank 1, verifies that rank 0 receives a
 `peer_failure_error` for rank 1, and confirms that the two surviving ranks

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -255,6 +255,7 @@ void process_completion_batch(runtime_t runtime, device_t device,
   for (size_t i = 0; i < count; i++) {
     const net_status_t& status = statuses[i];
     if (status.opcode == net_opcode_t::ERROR) {
+      device.get_impl()->mark_network_failed();
       const int failed_rank = get_failed_peer_rank(status);
       cleanup_failed_simple_operation(status);
       if (!has_failure) {

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -264,7 +264,7 @@ void process_completion_batch(runtime_t runtime, device_t device,
         first_failed_rank = failed_rank;
       }
     } else if (status.opcode == net_opcode_t::RECV) {
-      device.p_impl->consume_recvs(1);
+      device.get_impl()->consume_recvs(1);
       progress_recv(runtime, endpoint, status);
     } else if (status.opcode == net_opcode_t::SEND) {
       progress_send(status);

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -241,7 +241,14 @@ void free_endpoint_x::call_impl(endpoint_t* endpoint, runtime_t) const
   //     .runtime(endpoint->get_impl()->runtime)
   //     .device(endpoint->get_impl()->device)
   //     .endpoint (*endpoint)();
-  wait_drained_x().device(endpoint->get_impl()->device)();
+  device_t device = endpoint->get_impl()->device;
+  if (!device.get_impl()->has_network_failed()) {
+    wait_drained_x().device(device)();
+  } else {
+    LCI_Log(LOG_INFO, "network",
+            "Skip draining endpoint %d on failed device %d\n",
+            endpoint->get_impl()->idx_in_device, device.get_attr_uid());
+  }
   endpoint->get_impl()->device.p_impl->free_endpoint(*endpoint);
   endpoint->p_impl = nullptr;
 }

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -57,6 +57,14 @@ class device_impl_t
   inline bool post_recv_packets();
   inline bool refill_recvs(bool is_blocking = false);
   inline void consume_recvs(int n) { nrecvs_posted -= n; }
+  inline void mark_network_failed()
+  {
+    network_failed.store(true, std::memory_order_relaxed);
+  }
+  inline bool has_network_failed() const
+  {
+    return network_failed.load(std::memory_order_relaxed);
+  }
   static int reserve_device_ids(int n)
   {
     return g_ndevices.fetch_add(n, std::memory_order_relaxed);
@@ -85,6 +93,7 @@ class device_impl_t
   LCIU_CACHE_PADDING(sizeof(std::atomic<int>));
   std::atomic<size_t> nrecvs_posted;
   LCIU_CACHE_PADDING(sizeof(std::atomic<size_t>));
+  std::atomic<bool> network_failed{false};
 };
 
 class mr_impl_t

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -92,8 +92,8 @@ class device_impl_t
   static std::atomic<int> g_ndevices;
   LCIU_CACHE_PADDING(sizeof(std::atomic<int>));
   std::atomic<size_t> nrecvs_posted;
-  LCIU_CACHE_PADDING(sizeof(std::atomic<size_t>));
   std::atomic<bool> network_failed{false};
+  LCIU_CACHE_PADDING(sizeof(std::atomic<size_t>) + sizeof(std::atomic<bool>));
 };
 
 class mr_impl_t

--- a/tests/unit/loopback/test_network.hpp
+++ b/tests/unit/loopback/test_network.hpp
@@ -152,6 +152,33 @@ TEST(NETWORK, completion_batch_unknown_rank_is_generic)
   lci::g_runtime_fina();
 }
 
+TEST(NETWORK, completion_failure_uses_abortive_teardown)
+{
+  lci::g_runtime_init();
+  lci::runtime_t runtime = lci::g_default_runtime;
+  lci::device_t device = lci::get_default_device();
+  lci::endpoint_t endpoint = lci::get_default_endpoint();
+  EXPECT_FALSE(device.get_impl()->has_network_failed());
+
+  // Model an operation whose completion context is unavailable after a
+  // transport failure. Normal teardown would wait for this count forever.
+  endpoint.get_impl()->add_pending_ops();
+
+  lci::net_status_t status = {};
+  status.opcode = lci::net_opcode_t::ERROR;
+  status.rank = -1;
+  status.user_context = nullptr;
+
+  EXPECT_THROW(
+      lci::process_completion_batch(runtime, device, endpoint, &status, 1),
+      std::runtime_error);
+  EXPECT_TRUE(device.get_impl()->has_network_failed());
+
+  // A failed device abandons outstanding operations instead of hanging in
+  // wait_drained().
+  lci::g_runtime_fina();
+}
+
 TEST(NETWORK, reg_mem)
 {
   lci::g_runtime_init();


### PR DESCRIPTION
## Summary
- mark a device failed when asynchronous completion processing observes a network error
- skip `wait_drained()` during endpoint teardown only for failed devices
- preserve normal draining behavior for healthy devices
- document that abortive teardown may abandon outstanding completions
- add regression coverage for finalizing with an unavailable completion context and a stranded pending count

## Validation
- `banff20-14` IBV full loopback suite: `test-loopback-all` passed
- focused abortive-teardown regression: passed
- mixed IBV failure test with rank 2 sending healthy traffic to rank 0:
  - all 1,100 healthy messages delivered
  - no repeated exceptions after the first failure
  - both surviving ranks finalized
  - process exited successfully
- expected existing limitation: abortive teardown still reports one lost receive packet in the reproduced receive-side IBV failure path

Fixes #186
