### PR TITLE
Enable CXI write-with-immediate support

### DIFF
--- a/benchmarks/pt2pt/CMakeLists.txt
+++ b/benchmarks/pt2pt/CMakeLists.txt
@@ -22,6 +22,7 @@ add_lci_tests(
   "${LCI_USE_CTEST_LAUNCHER} -n 4 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 1024 --niters 1"
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 2 --nelems 1024 --niters 1"
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 1024 --niters 1 --remote-completion"
+  "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 32 --niters 1 --remote-completion"
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 32 --niters 1 --remote-completion --force-posted-writedata"
 )
 

--- a/benchmarks/pt2pt/CMakeLists.txt
+++ b/benchmarks/pt2pt/CMakeLists.txt
@@ -21,6 +21,7 @@ add_lci_tests(
   COMMANDS
   "${LCI_USE_CTEST_LAUNCHER} -n 4 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 1024 --niters 1"
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 2 --nelems 1024 --niters 1"
+  "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 1024 --niters 1 --remote-completion"
 )
 
 add_lci_executable(bench_am_lat bench_am_lat.cpp)

--- a/benchmarks/pt2pt/CMakeLists.txt
+++ b/benchmarks/pt2pt/CMakeLists.txt
@@ -25,6 +25,20 @@ add_lci_tests(
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 32 --niters 1 --remote-completion --force-posted-writedata"
 )
 
+add_lci_executable(bench_put_lat bench_put_lat.cpp)
+target_link_libraries(bench_put_lat PRIVATE cxxopts::cxxopts)
+add_lci_tests(
+  TESTS
+  bench_put_lat.cpp
+  LABELS
+  benchmark
+  DEPENDENCIES
+  cxxopts::cxxopts
+  COMMANDS
+  "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] --msg-size 32 --niters 2 --warmup-iters 1"
+  "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] --msg-size 32 --niters 2 --warmup-iters 1 --force-posted-writedata"
+)
+
 add_lci_executable(bench_am_lat bench_am_lat.cpp)
 target_link_libraries(bench_am_lat PRIVATE OpenMP::OpenMP_CXX cxxopts::cxxopts)
 add_lci_tests(

--- a/benchmarks/pt2pt/CMakeLists.txt
+++ b/benchmarks/pt2pt/CMakeLists.txt
@@ -22,6 +22,7 @@ add_lci_tests(
   "${LCI_USE_CTEST_LAUNCHER} -n 4 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 1024 --niters 1"
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 2 --nelems 1024 --niters 1"
   "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 1024 --niters 1 --remote-completion"
+  "${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] -t 1 --nelems 64 --msg-size 32 --niters 1 --remote-completion --force-posted-writedata"
 )
 
 add_lci_executable(bench_am_lat bench_am_lat.cpp)

--- a/benchmarks/pt2pt/bench_put_bw.cpp
+++ b/benchmarks/pt2pt/bench_put_bw.cpp
@@ -17,6 +17,7 @@ struct config_t {
   size_t msg_size = sizeof(int);
   size_t niters = 10;
   bool remote_completion = false;
+  bool force_posted_writedata = false;
 } g_config;
 
 void worker(int peer_rank, lci::device_t device, char* data, lci::mr_t mr,
@@ -37,6 +38,9 @@ void worker(int peer_rank, lci::device_t device, char* data, lci::mr_t mr,
                       .device(device)
                       .mr(mr)
                       .allow_done(false);
+        if (g_config.force_posted_writedata) {
+          op = op.comp_semantic(lci::comp_semantic_t::network);
+        }
         status = g_config.remote_completion ? op.remote_comp(rcomp)() : op();
         lci::progress_x().device(device)();
       } while (status.is_retry());
@@ -45,6 +49,9 @@ void worker(int peer_rank, lci::device_t device, char* data, lci::mr_t mr,
   size_t expected = g_config.niters * g_config.nelems;
   while (expected > lci::counter_get(comp)) {
     lci::progress_x().device(device)();
+  }
+  if (g_config.remote_completion) {
+    return;
   }
   // Drain network puts before signaling completion. The AM may use SHM, which
   // does not provide ordering with the preceding network puts.
@@ -67,6 +74,7 @@ int main(int argc, char** argv)
       ("s,msg-size", "Message size (bytes)", cxxopts::value<size_t>()->default_value(std::to_string(g_config.msg_size)))
       ("n,niters", "Number of iterations", cxxopts::value<size_t>()->default_value(std::to_string(g_config.niters)))
       ("r,remote-completion", "Request remote completion for every put", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
+      ("force-posted-writedata", "Benchmark-only: force remote-completion puts through the registered/posted network path", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
       ("h,help", "Print help")
       ;
   auto result = options.parse(argc, argv);
@@ -82,6 +90,9 @@ int main(int argc, char** argv)
   g_config.msg_size = result["msg-size"].as<size_t>();
   g_config.niters = result["niters"].as<size_t>();
   g_config.remote_completion = result["remote-completion"].as<bool>();
+  g_config.force_posted_writedata =
+      result["force-posted-writedata"].as<bool>();
+  assert(!g_config.force_posted_writedata || g_config.remote_completion);
 
   if (g_config.ndevices == -1) {
     g_config.ndevices = g_config.nthreads;
@@ -111,7 +122,10 @@ int main(int argc, char** argv)
               << g_config.ndevices << " devices, "
               << g_config.nelems << " elements, "
               << g_config.msg_size << " bytes per element, "
-              << (g_config.remote_completion ? "remote completion" : "normal put")
+              << (g_config.force_posted_writedata
+                      ? "forced posted writedata"
+                      : (g_config.remote_completion ? "remote completion"
+                                                    : "normal put"))
               << ", "
               << g_config.niters << " iterations" << std::endl;
   }
@@ -167,7 +181,7 @@ int main(int argc, char** argv)
       lci::device_t device = devices[device_idx];
       size_t expected =
           g_config.remote_completion
-              ? g_config.niters * g_config.nelems + g_config.nthreads
+              ? g_config.niters * g_config.nelems
               : g_config.nthreads;
       while (lci::counter_get(comp) < expected) {
         lci::progress_x().device(device)();

--- a/benchmarks/pt2pt/bench_put_bw.cpp
+++ b/benchmarks/pt2pt/bench_put_bw.cpp
@@ -14,10 +14,12 @@ struct config_t {
   int nthreads = 1;
   int ndevices = -1;
   size_t nelems = 65536;
+  size_t msg_size = sizeof(int);
   size_t niters = 10;
+  bool remote_completion = false;
 } g_config;
 
-void worker(int peer_rank, lci::device_t device, int *data, lci::mr_t mr,
+void worker(int peer_rank, lci::device_t device, char* data, lci::mr_t mr,
             lci::rmr_t rmr, lci::comp_t comp, lci::rcomp_t rcomp)
 {
   int thread_id = omp_get_thread_num();
@@ -29,11 +31,13 @@ void worker(int peer_rank, lci::device_t device, int *data, lci::mr_t mr,
     for (size_t j = thread_id; j < g_config.nelems; j += nthreads) {
       lci::status_t status;
       do {
-        status = lci::post_put_x(peer_rank, data + j, sizeof(int), comp,
-                                 j * sizeof(int), rmr)
-                     .device(device)
-                     .mr(mr)
-                     .allow_done(false)();
+        auto op = lci::post_put_x(peer_rank, data + j * g_config.msg_size,
+                                  g_config.msg_size, comp,
+                                  j * g_config.msg_size, rmr)
+                      .device(device)
+                      .mr(mr)
+                      .allow_done(false);
+        status = g_config.remote_completion ? op.remote_comp(rcomp)() : op();
         lci::progress_x().device(device)();
       } while (status.is_retry());
     }
@@ -60,7 +64,9 @@ int main(int argc, char** argv)
       ("t,nthreads", "Number of threads", cxxopts::value<int>()->default_value(std::to_string(g_config.nthreads)))
       ("d,ndevices", "Number of devices", cxxopts::value<int>()->default_value(std::to_string(g_config.ndevices)))
       ("N,nelems", "Number of elements", cxxopts::value<size_t>()->default_value(std::to_string(g_config.nelems)))
+      ("s,msg-size", "Message size (bytes)", cxxopts::value<size_t>()->default_value(std::to_string(g_config.msg_size)))
       ("n,niters", "Number of iterations", cxxopts::value<size_t>()->default_value(std::to_string(g_config.niters)))
+      ("r,remote-completion", "Request remote completion for every put", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
       ("h,help", "Print help")
       ;
   auto result = options.parse(argc, argv);
@@ -73,7 +79,9 @@ int main(int argc, char** argv)
   g_config.nthreads = result["nthreads"].as<int>();
   g_config.ndevices = result["ndevices"].as<int>();
   g_config.nelems = result["nelems"].as<size_t>();
+  g_config.msg_size = result["msg-size"].as<size_t>();
   g_config.niters = result["niters"].as<size_t>();
+  g_config.remote_completion = result["remote-completion"].as<bool>();
 
   if (g_config.ndevices == -1) {
     g_config.ndevices = g_config.nthreads;
@@ -102,6 +110,9 @@ int main(int argc, char** argv)
     std::cout << "Running with " << g_config.nthreads << " threads, "
               << g_config.ndevices << " devices, "
               << g_config.nelems << " elements, "
+              << g_config.msg_size << " bytes per element, "
+              << (g_config.remote_completion ? "remote completion" : "normal put")
+              << ", "
               << g_config.niters << " iterations" << std::endl;
   }
 
@@ -113,13 +124,13 @@ int main(int argc, char** argv)
   }
 
   // allocate memory
-  size_t size = g_config.nelems * sizeof(int);
+  size_t size = g_config.nelems * g_config.msg_size;
   void *data = malloc(size);
-  for (size_t i = 0; i < g_config.nelems; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     if (is_sender) {
-      ((int*)data)[i] = i + 1;
+      static_cast<char*>(data)[i] = static_cast<char>(i % 251 + 1);
     } else {
-      ((int*)data)[i] = 0;
+      static_cast<char*>(data)[i] = 0;
     }
   }
   std::vector<lci::mr_t> mrs(g_config.ndevices);
@@ -145,7 +156,7 @@ int main(int argc, char** argv)
     {
       int device_idx = omp_get_thread_num() % g_config.ndevices;
       lci::device_t device = devices[device_idx];
-      worker(peer_rank, device, (int*)data, mrs[device_idx],
+      worker(peer_rank, device, static_cast<char*>(data), mrs[device_idx],
              peer_rmrs[device_idx], comp, rcomp);
     }
   }
@@ -154,7 +165,11 @@ int main(int argc, char** argv)
     {
       int device_idx = omp_get_thread_num() % g_config.ndevices;
       lci::device_t device = devices[device_idx];
-      while (lci::counter_get(comp) < g_config.nthreads) {
+      size_t expected =
+          g_config.remote_completion
+              ? g_config.niters * g_config.nelems + g_config.nthreads
+              : g_config.nthreads;
+      while (lci::counter_get(comp) < expected) {
         lci::progress_x().device(device)();
       }
       lci::wait_drained_x().device(device)();
@@ -164,13 +179,19 @@ int main(int argc, char** argv)
   auto end = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = end - start;
   double total_msgs = g_config.niters * g_config.nelems * (nranks == 1 ? 1 : nranks / 2);
-  if (rank == 0)
+  if (rank == 0) {
+    double message_rate = total_msgs / elapsed.count();
     std::cout << "Elapsed time: " << elapsed.count() << " seconds; "
-              << "Message rate: " << (total_msgs / elapsed.count() / 1e6) << " Mmsgs/sec" << std::endl;
+              << "Message rate: " << message_rate / 1e6 << " Mmsgs/sec; "
+              << "Payload bandwidth: "
+              << message_rate * g_config.msg_size / 1e9 << " GB/s"
+              << std::endl;
+  }
   // verify data
   if (!is_sender) {
-    for (size_t i = 0; i < g_config.nelems; ++i) {
-      assert(((int*)data)[i] == i + 1);
+    for (size_t i = 0; i < size; ++i) {
+      assert(static_cast<char*>(data)[i] ==
+             static_cast<char>(i % 251 + 1));
     }
   }
 

--- a/benchmarks/pt2pt/bench_put_lat.cpp
+++ b/benchmarks/pt2pt/bench_put_lat.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 The LCI Project Authors
+// SPDX-License-Identifier: NCSA
+
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#include <cxxopts.hpp>
+
+#include "lci.hpp"
+
+struct config_t {
+  size_t msg_size = sizeof(int);
+  size_t niters = 1000;
+  size_t warmup_iters = 100;
+  bool force_posted_writedata = false;
+} g_config;
+
+static void wait_remote_completion(lci::device_t device, lci::comp_t comp)
+{
+  lci::status_t status;
+  do {
+    lci::progress_x().device(device)();
+    status = lci::cq_pop(comp);
+  } while (status.is_retry());
+  assert(status.is_done());
+}
+
+static void post_put(int peer_rank, void* buffer, lci::mr_t mr,
+                     lci::rmr_t peer_rmr, lci::device_t device,
+                     lci::rcomp_t rcomp)
+{
+  lci::status_t status;
+  do {
+    auto op = lci::post_put_x(peer_rank, buffer, g_config.msg_size,
+                              lci::COMP_NULL_RETRY, g_config.msg_size, peer_rmr)
+                  .device(device)
+                  .mr(mr)
+                  .remote_comp(rcomp);
+    if (g_config.force_posted_writedata) {
+      op = op.comp_semantic(lci::comp_semantic_t::network);
+    }
+    status = op();
+    lci::progress_x().device(device)();
+  } while (status.is_retry());
+}
+
+static void run_pingpong(size_t niters, bool is_initiator, int peer_rank,
+                         void* send_buffer, lci::mr_t mr, lci::rmr_t peer_rmr,
+                         lci::device_t device, lci::comp_t remote_comp,
+                         lci::rcomp_t rcomp)
+{
+  for (size_t i = 0; i < niters; ++i) {
+    if (is_initiator) {
+      post_put(peer_rank, send_buffer, mr, peer_rmr, device, rcomp);
+      wait_remote_completion(device, remote_comp);
+    } else {
+      wait_remote_completion(device, remote_comp);
+      post_put(peer_rank, send_buffer, mr, peer_rmr, device, rcomp);
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  cxxopts::Options options("lci_bench_put_lat",
+                           "Remote-completion PUT ping-pong latency test");
+  options.add_options()("s,msg-size", "Message size (bytes)",
+                        cxxopts::value<size_t>()->default_value(
+                            std::to_string(g_config.msg_size)))(
+      "n,niters", "Measured iterations",
+      cxxopts::value<size_t>()->default_value(std::to_string(g_config.niters)))(
+      "w,warmup-iters", "Warmup iterations",
+      cxxopts::value<size_t>()->default_value(
+          std::to_string(g_config.warmup_iters)))(
+      "force-posted-writedata",
+      "Force remote-completion PUTs through the registered/posted network path",
+      cxxopts::value<bool>()->default_value("false")->implicit_value("true"))(
+      "h,help", "Print help");
+  auto result = options.parse(argc, argv);
+
+  if (result.count("help")) {
+    std::cout << options.help() << std::endl;
+    return 0;
+  }
+
+  g_config.msg_size = result["msg-size"].as<size_t>();
+  g_config.niters = result["niters"].as<size_t>();
+  g_config.warmup_iters = result["warmup-iters"].as<size_t>();
+  g_config.force_posted_writedata = result["force-posted-writedata"].as<bool>();
+  assert(g_config.msg_size > 0);
+  assert(g_config.niters > 0);
+
+  lci::global_initialize();
+  lci::g_runtime_init_x().alloc_default_device(false)();
+
+  int rank = lci::get_rank_me();
+  int nranks = lci::get_rank_n();
+  assert(nranks == 2);
+  int peer_rank = 1 - rank;
+  bool is_initiator = rank == 0;
+
+  lci::device_t device = lci::alloc_device();
+  std::vector<char> data(2 * g_config.msg_size, 0);
+  void* send_buffer = data.data();
+  void* recv_buffer = data.data() + g_config.msg_size;
+  memset(send_buffer, rank + 1, g_config.msg_size);
+
+  lci::mr_t mr =
+      lci::register_memory_x(data.data(), data.size()).device(device)();
+  lci::rmr_t rmr = lci::get_rmr(mr);
+  std::vector<lci::rmr_t> all_rmrs(nranks);
+  lci::allgather_x(&rmr, all_rmrs.data(), sizeof(rmr)).device(device)();
+  lci::rmr_t peer_rmr = all_rmrs[peer_rank];
+
+  lci::comp_t remote_comp = lci::alloc_cq();
+  lci::rcomp_t rcomp = lci::register_rcomp(remote_comp);
+
+  lci::barrier_x().device(device)();
+  run_pingpong(g_config.warmup_iters, is_initiator, peer_rank, send_buffer, mr,
+               peer_rmr, device, remote_comp, rcomp);
+  lci::barrier_x().device(device)();
+
+  auto start = std::chrono::high_resolution_clock::now();
+  run_pingpong(g_config.niters, is_initiator, peer_rank, send_buffer, mr,
+               peer_rmr, device, remote_comp, rcomp);
+  lci::barrier_x().device(device)();
+  auto end = std::chrono::high_resolution_clock::now();
+  lci::wait_drained_x().device(device)();
+
+  for (size_t i = 0; i < g_config.msg_size; ++i) {
+    assert(static_cast<unsigned char*>(recv_buffer)[i] ==
+           static_cast<unsigned char>(peer_rank + 1));
+  }
+
+  if (rank == 0) {
+    std::chrono::duration<double> elapsed = end - start;
+    double round_trip_latency =
+        elapsed.count() / static_cast<double>(g_config.niters);
+    double put_latency = round_trip_latency / 2;
+    std::cout << "Running " << g_config.msg_size << "-byte "
+              << (g_config.force_posted_writedata ? "forced posted writedata"
+                                                  : "normal remote completion")
+              << " PUT ping-pong for " << g_config.niters
+              << " measured iterations" << std::endl;
+    std::cout << "Average round-trip latency: " << round_trip_latency * 1e6
+              << " us" << std::endl;
+    std::cout << "Average PUT latency: " << put_latency * 1e6 << " us"
+              << std::endl;
+    std::cout << "Message rate: "
+              << 2 * static_cast<double>(g_config.niters) / elapsed.count() /
+                     1e6
+              << " Mmsgs/s" << std::endl;
+  }
+
+  lci::free_comp(&remote_comp);
+  lci::deregister_memory(&mr);
+  lci::free_device(&device);
+  lci::g_runtime_fina();
+  lci::global_finalize();
+  return 0;
+}

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -69,6 +69,14 @@ bool ofi_net_context_impl_t::check_availability()
 ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
     : net_context_impl_t(runtime_, attr_)
 {
+  uint32_t v = fi_version();
+  int major = FI_MAJOR(v);
+  int minor = FI_MINOR(v);
+  const char* cxi_enable_writedata = getenv("FI_CXI_ENABLE_WRITEDATA");
+  bool cxi_writedata_requested = attr.ofi_provider_name == "cxi" &&
+                                 cxi_enable_writedata != nullptr &&
+                                 strcmp(cxi_enable_writedata, "1") == 0 &&
+                                 (major > 2 || (major == 2 && minor >= 5));
   char* prov_name_hint = dup_string_or_null(attr.ofi_provider_name);
   char* device_name_hint = dup_string_or_null(attr.device_name);
   struct fi_info* hints;
@@ -86,6 +94,9 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   hints->domain_attr->threading = FI_THREAD_SAFE;
   hints->tx_attr->inject_size = attr.max_inject_size;
   hints->caps = FI_RMA | FI_MSG;
+  if (cxi_writedata_requested) {
+    hints->caps |= FI_RMA_EVENT;
+  }
 #if defined(LCI_USE_CUDA) || defined(LCI_USE_HIP)
 #ifndef FI_HMEM
 #error "The current libfabric version does not have GPU support"
@@ -107,10 +118,6 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
                  __LINE__);
     }
   }
-  // Get libfabric version.
-  uint32_t v = fi_version();
-  int major = FI_MAJOR(v);
-  int minor = FI_MINOR(v);
   // According to the libfabric documentation, fi_getinfo call should
   // return the endpoints that are highest performing first.
   // But it appears cxi provider doesn't follow this rule,
@@ -184,8 +191,9 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   attr.support_putimm = true;
   std::string prov_name = ofi_info->fabric_attr->prov_name;
   if (prov_name == "cxi") {
-    // The CXI provider does not support write with immediate data.
-    attr.support_putimm = false;
+    // CXI added opt-in write-with-immediate support in libfabric 2.5.
+    attr.support_putimm =
+        cxi_writedata_requested && (ofi_info->caps & FI_RMA_EVENT);
   } else if (prov_name == "tcp" || prov_name.rfind("tcp;", 0) == 0) {
     if (major < 1 || (major == 1 && minor < 12)) {
       LCI_Warn(
@@ -219,6 +227,9 @@ ofi_device_impl_t::ofi_device_impl_t(net_context_t context_,
 {
   auto p_ofi_context = static_cast<ofi_net_context_impl_t*>(net_context.p_impl);
   ofi_domain_attr = p_ofi_context->ofi_info->domain_attr;
+  use_rma_event =
+      strcmp(p_ofi_context->ofi_info->fabric_attr->prov_name, "cxi") == 0 &&
+      p_ofi_context->attr.support_putimm;
   // Create domain.
   FI_SAFECALL(fi_domain(p_ofi_context->ofi_fabric, p_ofi_context->ofi_info,
                         &ofi_domain, nullptr));
@@ -379,7 +390,8 @@ mr_t ofi_device_impl_t::register_memory_impl(void* buffer, size_t size)
   struct fid_mr* ofi_mr;
   {
     ofi_lock_guard_t lock_guard(ofi_lock_mode, LCI_NET_LOCK_MR, lock);
-    FI_SAFECALL(fi_mr_regattr(ofi_domain, &mr_attr, 0, &ofi_mr));
+    FI_SAFECALL(fi_mr_regattr(ofi_domain, &mr_attr,
+                              use_rma_event ? FI_RMA_EVENT : 0, &ofi_mr));
 
     // FI_SAFECALL(fi_mr_reg(
     //     ofi_domain, buffer, size,

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -94,9 +94,6 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   hints->domain_attr->threading = FI_THREAD_SAFE;
   hints->tx_attr->inject_size = attr.max_inject_size;
   hints->caps = FI_RMA | FI_MSG;
-  if (cxi_writedata_requested) {
-    hints->caps |= FI_RMA_EVENT;
-  }
 #if defined(LCI_USE_CUDA) || defined(LCI_USE_HIP)
 #ifndef FI_HMEM
 #error "The current libfabric version does not have GPU support"
@@ -191,9 +188,13 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   attr.support_putimm = true;
   std::string prov_name = ofi_info->fabric_attr->prov_name;
   if (prov_name == "cxi") {
-    // CXI added opt-in write-with-immediate support in libfabric 2.5.
+    // CXI writedata uses provider keys and the domain's CQ-data support.
+    // FI_RMA_EVENT controls separate MR/counter event semantics and is not
+    // required for fi_writedata or fi_inject_writedata.
     attr.support_putimm =
-        cxi_writedata_requested && (ofi_info->caps & FI_RMA_EVENT);
+        cxi_writedata_requested &&
+        ofi_info->domain_attr->cq_data_size >= sizeof(net_imm_data_t) &&
+        (ofi_info->domain_attr->mr_mode & FI_MR_PROV_KEY);
   } else if (prov_name == "tcp" || prov_name.rfind("tcp;", 0) == 0) {
     if (major < 1 || (major == 1 && minor < 12)) {
       LCI_Warn(
@@ -227,7 +228,7 @@ ofi_device_impl_t::ofi_device_impl_t(net_context_t context_,
 {
   auto p_ofi_context = static_cast<ofi_net_context_impl_t*>(net_context.p_impl);
   ofi_domain_attr = p_ofi_context->ofi_info->domain_attr;
-  use_rma_event =
+  use_cxi_writedata =
       strcmp(p_ofi_context->ofi_info->fabric_attr->prov_name, "cxi") == 0 &&
       p_ofi_context->attr.support_putimm;
   // Create domain.
@@ -390,8 +391,7 @@ mr_t ofi_device_impl_t::register_memory_impl(void* buffer, size_t size)
   struct fid_mr* ofi_mr;
   {
     ofi_lock_guard_t lock_guard(ofi_lock_mode, LCI_NET_LOCK_MR, lock);
-    FI_SAFECALL(fi_mr_regattr(ofi_domain, &mr_attr,
-                              use_rma_event ? FI_RMA_EVENT : 0, &ofi_mr));
+    FI_SAFECALL(fi_mr_regattr(ofi_domain, &mr_attr, 0, &ofi_mr));
 
     // FI_SAFECALL(fi_mr_reg(
     //     ofi_domain, buffer, size,

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -104,7 +104,7 @@ class ofi_device_impl_t : public lci::device_impl_t
   struct fid_cq* ofi_cq;
   struct fid_av* ofi_av;
   std::vector<fi_addr_t> peer_addrs;
-  bool use_rma_event;
+  bool use_cxi_writedata;
   uint64_t& ofi_lock_mode;
   LCIU_CACHE_PADDING(0);
   spinlock_t lock;

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -134,6 +134,15 @@ class ofi_endpoint_impl_t : public lci::endpoint_impl_t
   error_t post_putImm_impl(int rank, void* buffer, size_t size, mr_t mr,
                            uint64_t offset, rmr_t rmr, net_imm_data_t imm_data,
                            void* user_context, bool high_priority) override;
+  // CXI rejects FI_REMOTE_CQ_DATA on fi_writemsg, so isolate use of the
+  // dedicated writedata entry points until the generic path is supported.
+  error_t cxi_inject_writedata_workaround(int rank, void* buffer, size_t size,
+                                          uint64_t offset, rmr_t rmr,
+                                          net_imm_data_t imm_data,
+                                          void* user_context);
+  error_t cxi_writedata_workaround(int rank, void* buffer, size_t size, mr_t mr,
+                                   uint64_t offset, rmr_t rmr,
+                                   net_imm_data_t imm_data, void* user_context);
   error_t post_get_impl(int rank, void* buffer, size_t size, mr_t mr,
                         uint64_t offset, rmr_t rmr, void* user_context,
                         bool high_priority) override;

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -104,6 +104,7 @@ class ofi_device_impl_t : public lci::device_impl_t
   struct fid_cq* ofi_cq;
   struct fid_av* ofi_av;
   std::vector<fi_addr_t> peer_addrs;
+  bool use_rma_event;
   uint64_t& ofi_lock_mode;
   LCIU_CACHE_PADDING(0);
   spinlock_t lock;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -275,8 +275,13 @@ inline error_t ofi_endpoint_impl_t::post_put_impl(int rank, void* buffer,
 
 inline error_t ofi_endpoint_impl_t::post_putImms_impl(
     int rank, void* buffer, size_t size, uint64_t offset, rmr_t rmr,
-    net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
+    net_imm_data_t imm_data, void* user_context, bool high_priority)
 {
+  if (p_ofi_device->use_rma_event) {
+    // CXI fi_inject_writedata does not generate the remote completion.
+    return post_putImms_fallback(rank, buffer, size, offset, rmr, imm_data,
+                                 user_context, high_priority);
+  }
   uintptr_t addr =
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   struct fi_msg_rma msg;
@@ -299,8 +304,6 @@ inline error_t ofi_endpoint_impl_t::post_putImms_impl(
   ssize_t ret = fi_writemsg(
       ofi_ep, &msg,
       FI_INJECT | FI_COMPLETION | FI_DELIVERY_COMPLETE | FI_REMOTE_CQ_DATA);
-  // ssize_t ret = fi_inject_writedata(ofi_ep, buffer, size, imm_data,
-  //                                   peer_addrs[rank], addr, rmr.opaque_rkey);
   LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
   if (ret == FI_SUCCESS)
     return errorcode_t::done;
@@ -317,28 +320,33 @@ inline error_t ofi_endpoint_impl_t::post_putImm_impl(
 {
   uintptr_t addr =
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
-  struct fi_msg_rma msg;
-  struct iovec iov;
-  struct fi_rma_iov riov;
-  void* desc = ofi_detail::get_mr_desc(mr);
-  iov.iov_base = buffer;
-  iov.iov_len = size;
-  msg.msg_iov = &iov;
-  msg.desc = &desc;
-  msg.iov_count = 1;
-  msg.addr = peer_addrs[rank];
-  riov.addr = addr;
-  riov.len = size;
-  riov.key = rmr.opaque_rkey;
-  msg.rma_iov = &riov;
-  msg.rma_iov_count = 1;
-  msg.context = user_context;
-  msg.data = imm_data;
   LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
-  ssize_t ret = fi_writemsg(
-      ofi_ep, &msg, FI_COMPLETION | FI_DELIVERY_COMPLETE | FI_REMOTE_CQ_DATA);
-  // fi_writedata(ofi_ep, buffer, size, ofi_detail::get_mr_desc(mr), imm_data,
-  //                  peer_addrs[rank], addr, rmr.opaque_rkey, user_context);
+  ssize_t ret;
+  if (p_ofi_device->use_rma_event) {
+    ret = fi_writedata(ofi_ep, buffer, size, ofi_detail::get_mr_desc(mr),
+                       imm_data, peer_addrs[rank], addr, rmr.opaque_rkey,
+                       user_context);
+  } else {
+    struct fi_msg_rma msg;
+    struct iovec iov;
+    struct fi_rma_iov riov;
+    void* desc = ofi_detail::get_mr_desc(mr);
+    iov.iov_base = buffer;
+    iov.iov_len = size;
+    msg.msg_iov = &iov;
+    msg.desc = &desc;
+    msg.iov_count = 1;
+    msg.addr = peer_addrs[rank];
+    riov.addr = addr;
+    riov.len = size;
+    riov.key = rmr.opaque_rkey;
+    msg.rma_iov = &riov;
+    msg.rma_iov_count = 1;
+    msg.context = user_context;
+    msg.data = imm_data;
+    ret = fi_writemsg(ofi_ep, &msg,
+                      FI_COMPLETION | FI_DELIVERY_COMPLETE | FI_REMOTE_CQ_DATA);
+  }
   LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
   if (ret == FI_SUCCESS)
     return errorcode_t::posted;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -279,7 +279,7 @@ inline error_t ofi_endpoint_impl_t::post_putImms_impl(
 {
   uintptr_t addr =
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
-  if (p_ofi_device->use_rma_event) {
+  if (p_ofi_device->use_cxi_writedata) {
     LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
     ssize_t ret = fi_inject_writedata(ofi_ep, buffer, size, imm_data,
                                       peer_addrs[rank], addr, rmr.opaque_rkey);
@@ -337,7 +337,7 @@ inline error_t ofi_endpoint_impl_t::post_putImm_impl(
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
   ssize_t ret;
-  if (p_ofi_device->use_rma_event) {
+  if (p_ofi_device->use_cxi_writedata) {
     ret = fi_writedata(ofi_ep, buffer, size, ofi_detail::get_mr_desc(mr),
                        imm_data, peer_addrs[rank], addr, rmr.opaque_rkey,
                        user_context);

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -275,17 +275,30 @@ inline error_t ofi_endpoint_impl_t::post_put_impl(int rank, void* buffer,
 
 inline error_t ofi_endpoint_impl_t::post_putImms_impl(
     int rank, void* buffer, size_t size, uint64_t offset, rmr_t rmr,
-    net_imm_data_t imm_data, void* user_context, bool high_priority)
+    net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
 {
-  if (p_ofi_device->use_rma_event) {
-    // Keep the software fallback for CXI inject-sized operations. Direct
-    // fi_inject_writedata works with libfabric 2.6, but LCI teardown hangs
-    // after using it.
-    return post_putImms_fallback(rank, buffer, size, offset, rmr, imm_data,
-                                 user_context, high_priority);
-  }
   uintptr_t addr =
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
+  if (p_ofi_device->use_rma_event) {
+    LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
+    ssize_t ret = fi_inject_writedata(ofi_ep, buffer, size, imm_data,
+                                      peer_addrs[rank], addr, rmr.opaque_rkey);
+    LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
+    if (ret == FI_SUCCESS) {
+      // fi_inject_writedata does not generate a local CQ completion. FI_INJECT
+      // has already copied the source buffer, so retire the internal context
+      // here instead of leaving the endpoint's pending operation count stuck.
+      if (user_context) {
+        free_ctx_and_signal_comp(
+            static_cast<internal_context_t*>(user_context));
+      }
+      return errorcode_t::done;
+    } else if (ret == -FI_EAGAIN)
+      return errorcode_t::retry_nomem;
+    else {
+      FI_SAFECALL_RET(ret);
+    }
+  }
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -273,32 +273,41 @@ inline error_t ofi_endpoint_impl_t::post_put_impl(int rank, void* buffer,
   }
 }
 
+inline error_t ofi_endpoint_impl_t::cxi_inject_writedata_workaround(
+    int rank, void* buffer, size_t size, uint64_t offset, rmr_t rmr,
+    net_imm_data_t imm_data, void* user_context)
+{
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
+  LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
+  ssize_t ret = fi_inject_writedata(ofi_ep, buffer, size, imm_data,
+                                    peer_addrs[rank], addr, rmr.opaque_rkey);
+  LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
+  if (ret == FI_SUCCESS) {
+    // fi_inject_writedata does not generate a local CQ completion. FI_INJECT
+    // has already copied the source buffer, so retire the internal context
+    // here instead of leaving the endpoint's pending operation count stuck.
+    if (user_context) {
+      free_ctx_and_signal_comp(static_cast<internal_context_t*>(user_context));
+    }
+    return errorcode_t::done;
+  } else if (ret == -FI_EAGAIN)
+    return errorcode_t::retry_nomem;
+  else {
+    FI_SAFECALL_RET(ret);
+  }
+}
+
 inline error_t ofi_endpoint_impl_t::post_putImms_impl(
     int rank, void* buffer, size_t size, uint64_t offset, rmr_t rmr,
     net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
 {
+  if (p_ofi_device->use_cxi_writedata) {
+    return cxi_inject_writedata_workaround(rank, buffer, size, offset, rmr,
+                                           imm_data, user_context);
+  }
   uintptr_t addr =
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
-  if (p_ofi_device->use_cxi_writedata) {
-    LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
-    ssize_t ret = fi_inject_writedata(ofi_ep, buffer, size, imm_data,
-                                      peer_addrs[rank], addr, rmr.opaque_rkey);
-    LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
-    if (ret == FI_SUCCESS) {
-      // fi_inject_writedata does not generate a local CQ completion. FI_INJECT
-      // has already copied the source buffer, so retire the internal context
-      // here instead of leaving the endpoint's pending operation count stuck.
-      if (user_context) {
-        free_ctx_and_signal_comp(
-            static_cast<internal_context_t*>(user_context));
-      }
-      return errorcode_t::done;
-    } else if (ret == -FI_EAGAIN)
-      return errorcode_t::retry_nomem;
-    else {
-      FI_SAFECALL_RET(ret);
-    }
-  }
   struct fi_msg_rma msg;
   struct iovec iov;
   struct fi_rma_iov riov;
@@ -329,39 +338,56 @@ inline error_t ofi_endpoint_impl_t::post_putImms_impl(
   }
 }
 
-inline error_t ofi_endpoint_impl_t::post_putImm_impl(
+inline error_t ofi_endpoint_impl_t::cxi_writedata_workaround(
     int rank, void* buffer, size_t size, mr_t mr, uint64_t offset, rmr_t rmr,
-    net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
+    net_imm_data_t imm_data, void* user_context)
 {
   uintptr_t addr =
       ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
   LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
-  ssize_t ret;
-  if (p_ofi_device->use_cxi_writedata) {
-    ret = fi_writedata(ofi_ep, buffer, size, ofi_detail::get_mr_desc(mr),
-                       imm_data, peer_addrs[rank], addr, rmr.opaque_rkey,
-                       user_context);
-  } else {
-    struct fi_msg_rma msg;
-    struct iovec iov;
-    struct fi_rma_iov riov;
-    void* desc = ofi_detail::get_mr_desc(mr);
-    iov.iov_base = buffer;
-    iov.iov_len = size;
-    msg.msg_iov = &iov;
-    msg.desc = &desc;
-    msg.iov_count = 1;
-    msg.addr = peer_addrs[rank];
-    riov.addr = addr;
-    riov.len = size;
-    riov.key = rmr.opaque_rkey;
-    msg.rma_iov = &riov;
-    msg.rma_iov_count = 1;
-    msg.context = user_context;
-    msg.data = imm_data;
-    ret = fi_writemsg(ofi_ep, &msg,
-                      FI_COMPLETION | FI_DELIVERY_COMPLETE | FI_REMOTE_CQ_DATA);
+  ssize_t ret =
+      fi_writedata(ofi_ep, buffer, size, ofi_detail::get_mr_desc(mr), imm_data,
+                   peer_addrs[rank], addr, rmr.opaque_rkey, user_context);
+  LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
+  if (ret == FI_SUCCESS)
+    return errorcode_t::posted;
+  else if (ret == -FI_EAGAIN)
+    return errorcode_t::retry_nomem;
+  else {
+    FI_SAFECALL_RET(ret);
   }
+}
+
+inline error_t ofi_endpoint_impl_t::post_putImm_impl(
+    int rank, void* buffer, size_t size, mr_t mr, uint64_t offset, rmr_t rmr,
+    net_imm_data_t imm_data, void* user_context, bool /*high_priority*/)
+{
+  if (p_ofi_device->use_cxi_writedata) {
+    return cxi_writedata_workaround(rank, buffer, size, mr, offset, rmr,
+                                    imm_data, user_context);
+  }
+  uintptr_t addr =
+      ofi_detail::get_remote_addr(rmr, offset, ofi_domain_attr->mr_mode);
+  struct fi_msg_rma msg;
+  struct iovec iov;
+  struct fi_rma_iov riov;
+  void* desc = ofi_detail::get_mr_desc(mr);
+  iov.iov_base = buffer;
+  iov.iov_len = size;
+  msg.msg_iov = &iov;
+  msg.desc = &desc;
+  msg.iov_count = 1;
+  msg.addr = peer_addrs[rank];
+  riov.addr = addr;
+  riov.len = size;
+  riov.key = rmr.opaque_rkey;
+  msg.rma_iov = &riov;
+  msg.rma_iov_count = 1;
+  msg.context = user_context;
+  msg.data = imm_data;
+  LCI_OFI_CS_TRY_ENTER(LCI_NET_TRYLOCK_SEND, errorcode_t::retry_lock);
+  ssize_t ret = fi_writemsg(
+      ofi_ep, &msg, FI_COMPLETION | FI_DELIVERY_COMPLETE | FI_REMOTE_CQ_DATA);
   LCI_OFI_CS_EXIT(LCI_NET_TRYLOCK_SEND);
   if (ret == FI_SUCCESS)
     return errorcode_t::posted;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -278,7 +278,9 @@ inline error_t ofi_endpoint_impl_t::post_putImms_impl(
     net_imm_data_t imm_data, void* user_context, bool high_priority)
 {
   if (p_ofi_device->use_rma_event) {
-    // CXI fi_inject_writedata does not generate the remote completion.
+    // Keep the software fallback for CXI inject-sized operations. Direct
+    // fi_inject_writedata works with libfabric 2.6, but LCI teardown hangs
+    // after using it.
     return post_putImms_fallback(rank, buffer, size, offset, rmr, imm_data,
                                  user_context, high_priority);
   }


### PR DESCRIPTION
## Summary

This PR enables opt-in CXI write-with-immediate support with libfabric 2.5+ when `FI_CXI_ENABLE_WRITEDATA=1`:

- enable CXI writedata from CQ-data support and provider MR keys without requesting unrelated `FI_RMA_EVENT` semantics;
- use `fi_inject_writedata` for inject-sized CXI PUTs with remote completion;
- use registered `fi_writedata` above the inject threshold;
- correctly retire LCI's internal context after successful completion-less inject submission, fixing the teardown hang;
- extend `lci_bench_put_bw` with configurable message size, remote completion, validation, and `--force-posted-writedata`;
- add `lci_bench_put_lat`, a two-rank remote-completion PUT ping-pong benchmark;
- add an inject-sized remote-completion benchmark test to cover teardown.

Final validation uses **libfabric 2.6.0** with libcxi 1.8.0 on Lockhart. The earlier libfabric 2.5.1 observations are historical only.

## Final protocol selection

With writedata enabled, CXI reports `inject_size=192` and `cq_data_size=8`. CXI creates its dedicated dual MR entries from the domain's `rma_cq_data_size`; `FI_RMA_EVENT` is not required for writedata and is intentionally not requested on the endpoint or memory registrations.

- **4–192 B:** LCI's inject protocol uses `fi_inject_writedata`.
- **256 B and above:** registered/posted remote-completion PUTs use `fi_writedata`.
- **`--force-posted-writedata`:** benchmark-only control that forces registered `fi_writedata` below the inject threshold by requesting network completion semantics.
- **Writedata disabled:** `support_putimm=0`; LCI retains the generic software fallback for compatibility:

  ```text
  PUT
  → separate zero-byte notification message
  ```

## Teardown hang: root cause and fix

The original direct `fi_inject_writedata` experiment completed communication and payload validation but hung in teardown. Job `974206` reproduced the failure with a 20-second timeout.

A stack capture in job `974213` showed rank 0 blocked in:

```text
free_device
→ free_endpoint
→ wait_drained
→ test_drained
```

The hang was in LCI, not `fi_close` or CXI provider teardown:

1. LCI creates an `internal_context_t` for the user operation and increments the endpoint's `pending_ops` count.
2. Normal OFI inject implementations request a local CQ completion, which eventually releases that context.
3. `fi_inject_writedata` has no local CQ completion by API design.
4. The context was therefore never released, leaving `pending_ops == 1` forever and causing `wait_drained()` to spin.

The fix retires the internal context immediately after successful `fi_inject_writedata`. This is safe because `FI_INJECT` guarantees the provider has copied the source buffer before returning. Retry paths retain the context as before.

## Correctness and teardown validation

- libfabric 2.6.0 build: job `974111`.
- Initial direct libfabric matrix: job `974114`.
- Final direct matrix without `FI_RMA_EVENT`: job `974265`.
  - endpoint capabilities excluded `FI_RMA_EVENT` and MR registration flags were zero;
  - posted `fi_writedata` passed from 4 B through 4 KiB;
  - `fi_inject_writedata` passed at every valid inject size: 4, 8, 16, 32, 64, 128, and 192 B;
  - submission, local completion where applicable, target CQ data, and every payload byte were verified.
- Pre-fix reproduction: job `974206` timed out after communication completed.
- Stack/root-cause capture: job `974213`.
- Focused post-fix smoke: job `974215` completed communication and teardown in under one second.
- High-volume/teardown validation: job `974216`.
  - 32,768 operations at each inject size, 229,376 total direct inject-writedata operations;
  - payload validation passed at every size;
  - 25 repeated one-operation process teardown tests passed;
  - forced-posted and writedata-disabled fallback controls passed.
- Final no-`FI_RMA_EVENT` LCI correctness matrix: job `974266`.
  - capabilities excluded `FI_RMA_EVENT` while `support_putimm=1`;
  - normal PUT, direct inject writedata, forced posted writedata, posted sizes, rendezvous writeimm, and writedata-disabled fallback all passed.
- Final high-volume/teardown validation: job `974267`; all inject sizes and 25 repeated teardowns passed.
- Final two-thread/two-device validation: job `974268` passed at 4 and 192 B with 32,768 operations per size.
- No-`FI_RMA_EVENT` performance revalidation: job `974269`.

## Small-message performance after the fix

Job `974269` used the healthy MI250X A1 pair, host memory, one rank/node, one thread/device, ten balanced-order repetitions, 32,768 operations per bandwidth sample, and 5,000 ping-pong iterations per latency sample.

Modes:

- **normal:** normal PUT without remote completion;
- **inject writedata:** normal remote-completion PUT, now selecting `fi_inject_writedata`;
- **posted writedata:** `--force-posted-writedata`.

Median results:

| Size | Normal PUT | Inject writedata | Posted writedata | Inject vs normal | Inject PUT latency | Posted PUT latency |
|---:|---:|---:|---:|---:|---:|---:|
| 4 B | 1.3975 Mmsg/s | 1.4619 Mmsg/s | 0.0931 Mmsg/s | +4.61% | 3.2904 us | 6.4354 us |
| 8 B | 1.3919 Mmsg/s | 1.4649 Mmsg/s | 0.0930 Mmsg/s | +5.24% | 3.3077 us | 6.4290 us |
| 16 B | 1.3972 Mmsg/s | 1.4569 Mmsg/s | 0.0932 Mmsg/s | +4.27% | 3.2955 us | 6.4434 us |
| 32 B | 1.3872 Mmsg/s | 1.4720 Mmsg/s | 0.0932 Mmsg/s | +6.11% | 3.4458 us | 6.4607 us |
| 64 B | 1.3861 Mmsg/s | 1.4686 Mmsg/s | 0.0929 Mmsg/s | +5.95% | 3.2189 us | 6.4347 us |
| 128 B | 1.3893 Mmsg/s | 1.4711 Mmsg/s | 0.0924 Mmsg/s | +5.89% | 3.4535 us | 6.4845 us |
| 192 B | 1.3787 Mmsg/s | 1.4554 Mmsg/s | 0.0923 Mmsg/s | +5.56% | 3.4567 us | 6.4812 us |

Key conclusions:

- Direct inject writedata sustains **1.45–1.48 Mmsg/s**, about **4–7% above normal PUT** in this test and about **15.7× the forced posted-writedata message rate**.
- Direct inject writedata latency is **3.22–3.47 us/PUT**, about **46–50% lower than posted writedata**.
- Compared with the old software fallback at about 12.8 us/PUT, direct inject writedata removes the extra notification message and reduces latency by roughly 73–75%.
- The earlier conclusion that the inject-sized software fallback had better streaming throughput is superseded: direct inject writedata is both the lowest-latency and highest-throughput remote-completion path at 4–192 B.

All paired confidence intervals for inject-vs-normal bandwidth and inject-vs-posted latency exclude zero.

## Software fallback vs posted writedata control

Job `974192` disabled writedata to force LCI's generic software fallback at every size, then compared it with registered writedata. This remains useful as a compatibility-path control, but it no longer represents normal CXI selection when writedata is enabled.

Selected median per-PUT latencies:

| Size | Software fallback | Posted writedata | Posted improvement |
|---:|---:|---:|---:|
| 4 B | 12.8349 us | 6.4428 us | 49.80% |
| 192 B | 12.8130 us | 6.4678 us | 49.52% |
| 256 B | 25.5725 us | 6.5476 us | 74.40% |
| 4 KiB | 26.6023 us | 7.1096 us | 73.27% |
| 64 KiB | 37.1413 us | 11.7199 us | 68.45% |
| 1 MiB | 156.3545 us | 86.0376 us | 44.97% |

The fallback's jump at 256 B comes from waiting for a posted write completion before sending the separate notification message.

## Official fabtests comparison

The initial fabtests patch unnecessarily requested `FI_RMA_EVENT`; the provider source and final direct matrix `974265` show that writedata does not require it. The latency result from job `974166` remains a valid posted `fi_write` versus posted `fi_writedata` comparison, but the extra flags were not part of the required mechanism.

Posted writedata added roughly 0.4–0.6 us because the target processes a CQ-data event instead of polling memory. This isolates target CQ-data handling overhead and does not include LCI's old separate notification message. It also does not measure the inject-writedata path enabled by the final fix.

## Large-message and rendezvous results

Above 192 B, the registered `fi_writedata` results from job `974134` remain unchanged:

- 256 B–128 KiB: normal, remote, and forced-posted PUT throughput are generally close;
- 256 KiB: remote and forced posted are about 5.1% below normal;
- 512 KiB and 1 MiB: remote/posted modes were about 2–3% above normal in the measured pair.

For AM rendezvous, writeimm consistently reduced round-trip latency from 8 KiB through 1 MiB, by roughly 1.35–1.57% from 16–512 KiB and 1.24% at 1 MiB.

## Historical libfabric 2.5.1 observation

With libfabric 2.5.1, posted writedata was correct, but isolated 4-byte `fi_inject_writedata` timed out waiting for the target CQ event. Libfabric 2.6.0 fixes that provider behavior; this PR additionally fixes the separate LCI context-retirement bug that caused teardown to hang.

## Limitations

- one healthy MI250X A1 node pair;
- host memory only;
- primary performance data uses one rank/node and one thread/device;
- two-thread/two-device coverage is correctness/stress only;
- no GPU-memory, congestion, or scaling study.

Fixes #188

