### PR TITLE
Add uint64 network fetch-add support

### DIFF
--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -80,6 +80,21 @@ enum attr_net_lock_mode_t {
   LCI_NET_TRYLOCK_MAX = 1 << 4,
 };
 
+/**
+ * @brief The scope at which a network backend guarantees uint64 atomics.
+ * @ingroup LCI_BASIC
+ *
+ * This reports the scope advertised by the selected backend. In particular,
+ * @ref net_atomic_scope_t::HCA maps to @c IBV_ATOMIC_HCA and must not be
+ * treated as global atomicity. Callers request the scope their algorithm
+ * requires when posting a network atomic operation.
+ */
+enum class net_atomic_scope_t {
+  NONE = 0,   /**< uint64 network atomics are unavailable */
+  HCA = 1,    /**< atomic only within the scope reported by one HCA */
+  GLOBAL = 2, /**< backend reports global atomic scope */
+};
+
 // mimic std::optional as we don't want to force c++17 for now
 template <typename T>
 struct option_t {
@@ -241,14 +256,19 @@ struct error_t {
  * @ingroup LCI_BASIC
  */
 enum class net_opcode_t {
-  SEND,         /**< send */
-  RECV,         /**< receive */
-  WRITE,        /**< write */
-  REMOTE_WRITE, /**< remote write */
-  READ,         /**< read */
-  FETCH_ADD,    /**< uint64 fetch-add or add */
-  ERROR,        /**< asynchronous completion error */
+  SEND = 0,         /**< send */
+  RECV = 1,         /**< receive */
+  WRITE = 2,        /**< write */
+  REMOTE_WRITE = 3, /**< remote write */
+  READ = 4,         /**< read */
+  ERROR = 5,        /**< asynchronous completion error */
+  FETCH_ADD = 6,    /**< uint64 fetch-add or add */
 };
+
+static_assert(static_cast<int>(net_opcode_t::ERROR) == 5,
+              "net_opcode_t::ERROR is part of the public ABI");
+static_assert(static_cast<int>(net_opcode_t::FETCH_ADD) == 6,
+              "append new net_opcode_t values to preserve the public ABI");
 
 /**
  * @brief Get the string representation of a network operation code.
@@ -324,8 +344,10 @@ using net_imm_data_t = uint32_t;
  * @details A network status is used to describe a completed network
  * communication operation. For @ref net_opcode_t::ERROR, @c rank is the
  * backend-reported peer rank when available and @c user_context is the
- * outgoing operation context when available. Receive errors report rank -1 and
- * a null user context.
+ * outgoing operation context when available. @c failed_opcode identifies the
+ * failed operation when the backend can provide it; raw uint64 atomic failures
+ * use @ref net_opcode_t::FETCH_ADD. Receive errors report rank -1 and a null
+ * user context.
  */
 struct net_status_t {
   net_opcode_t opcode;
@@ -333,6 +355,7 @@ struct net_status_t {
   void* user_context;
   size_t length;
   net_imm_data_t imm_data;
+  net_opcode_t failed_opcode;
 };
 
 /**

--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -256,18 +256,21 @@ struct error_t {
  * @ingroup LCI_BASIC
  */
 enum class net_opcode_t {
-  SEND = 0,         /**< send */
-  RECV = 1,         /**< receive */
-  WRITE = 2,        /**< write */
-  REMOTE_WRITE = 3, /**< remote write */
-  READ = 4,         /**< read */
-  ERROR = 5,        /**< asynchronous completion error */
-  FETCH_ADD = 6,    /**< uint64 fetch-add or add */
+  SEND = 0,            /**< send */
+  RECV = 1,            /**< receive */
+  WRITE = 2,           /**< write */
+  REMOTE_WRITE = 3,    /**< remote write */
+  READ = 4,            /**< read */
+  ERROR = 5,           /**< asynchronous completion error */
+  FETCH_ADD = 6,       /**< uint64 fetch-add or add */
+  FETCH_ADD_ERROR = 7, /**< uint64 fetch-add or add completion error */
 };
 
 static_assert(static_cast<int>(net_opcode_t::ERROR) == 5,
               "net_opcode_t::ERROR is part of the public ABI");
 static_assert(static_cast<int>(net_opcode_t::FETCH_ADD) == 6,
+              "append new net_opcode_t values to preserve the public ABI");
+static_assert(static_cast<int>(net_opcode_t::FETCH_ADD_ERROR) == 7,
               "append new net_opcode_t values to preserve the public ABI");
 
 /**
@@ -345,8 +348,9 @@ using net_imm_data_t = uint32_t;
  * communication operation. For @ref net_opcode_t::ERROR, @c rank is the
  * backend-reported peer rank when available and @c user_context is the
  * outgoing operation context when available. Receive errors report rank -1 and
- * a null user context. Raw uint64 atomic failures also report a null user
- * context because their contexts are not LCI internal contexts.
+ * a null user context. For @ref net_opcode_t::FETCH_ADD_ERROR,
+ * @c user_context is the raw context passed to the uint64 atomic operation;
+ * it is not an LCI internal context.
  */
 struct net_status_t {
   net_opcode_t opcode;

--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -344,10 +344,9 @@ using net_imm_data_t = uint32_t;
  * @details A network status is used to describe a completed network
  * communication operation. For @ref net_opcode_t::ERROR, @c rank is the
  * backend-reported peer rank when available and @c user_context is the
- * outgoing operation context when available. @c failed_opcode identifies the
- * failed operation when the backend can provide it; raw uint64 atomic failures
- * use @ref net_opcode_t::FETCH_ADD. Receive errors report rank -1 and a null
- * user context.
+ * outgoing operation context when available. Receive errors report rank -1 and
+ * a null user context. Raw uint64 atomic failures also report a null user
+ * context because their contexts are not LCI internal contexts.
  */
 struct net_status_t {
   net_opcode_t opcode;
@@ -355,7 +354,6 @@ struct net_status_t {
   void* user_context;
   size_t length;
   net_imm_data_t imm_data;
-  net_opcode_t failed_opcode;
 };
 
 /**

--- a/src/api/lci.hpp
+++ b/src/api/lci.hpp
@@ -246,6 +246,7 @@ enum class net_opcode_t {
   WRITE,        /**< write */
   REMOTE_WRITE, /**< remote write */
   READ,         /**< read */
+  FETCH_ADD,    /**< uint64 fetch-add or add */
   ERROR,        /**< asynchronous completion error */
 };
 

--- a/src/backlog_queue/backlog_queue.hpp
+++ b/src/backlog_queue/backlog_queue.hpp
@@ -54,6 +54,7 @@ class backlog_queue_t
                        net_atomic_scope_t required_atomic_scope,
                        void* user_context);
   inline bool progress();
+  inline size_t abort();
   inline void set_empty(bool empty_)
   {
     if (empty.val.load(std::memory_order_relaxed) != empty_) {

--- a/src/backlog_queue/backlog_queue.hpp
+++ b/src/backlog_queue/backlog_queue.hpp
@@ -46,9 +46,13 @@ class backlog_queue_t
                        void* user_context);
   inline void push_fetch_add(endpoint_impl_t* endpoint, int rank,
                              uint64_t* result, mr_t result_mr, uint64_t value,
-                             uint64_t offset, rmr_t rmr, void* user_context);
+                             uint64_t offset, rmr_t rmr,
+                             net_atomic_scope_t required_atomic_scope,
+                             void* user_context);
   inline void push_add(endpoint_impl_t* endpoint, int rank, uint64_t value,
-                       uint64_t offset, rmr_t rmr, void* user_context);
+                       uint64_t offset, rmr_t rmr,
+                       net_atomic_scope_t required_atomic_scope,
+                       void* user_context);
   inline bool progress();
   inline void set_empty(bool empty_)
   {
@@ -88,6 +92,7 @@ class backlog_queue_t
     rmr_t rmr;
     net_imm_data_t imm_data;
     uint64_t value;
+    net_atomic_scope_t required_atomic_scope;
     void* user_context;
   };
   // we use a lock-based queue instead of a atomic-based queue for two reasons:

--- a/src/backlog_queue/backlog_queue.hpp
+++ b/src/backlog_queue/backlog_queue.hpp
@@ -44,6 +44,11 @@ class backlog_queue_t
   inline void push_get(endpoint_impl_t* endpoint, int rank, void* buffer,
                        size_t size, mr_t mr, uint64_t offset, rmr_t rmr,
                        void* user_context);
+  inline void push_fetch_add(endpoint_impl_t* endpoint, int rank,
+                             uint64_t* result, mr_t result_mr, uint64_t value,
+                             uint64_t offset, rmr_t rmr, void* user_context);
+  inline void push_add(endpoint_impl_t* endpoint, int rank, uint64_t value,
+                       uint64_t offset, rmr_t rmr, void* user_context);
   inline bool progress();
   inline void set_empty(bool empty_)
   {
@@ -69,6 +74,8 @@ class backlog_queue_t
     putImms,
     putImm,
     get,
+    fetch_add,
+    add,
   };
   struct backlog_queue_entry_t {
     backlog_op_t op;
@@ -80,6 +87,7 @@ class backlog_queue_t
     uint64_t offset;
     rmr_t rmr;
     net_imm_data_t imm_data;
+    uint64_t value;
     void* user_context;
   };
   // we use a lock-based queue instead of a atomic-based queue for two reasons:

--- a/src/backlog_queue/backlog_queue_inline.hpp
+++ b/src/backlog_queue/backlog_queue_inline.hpp
@@ -179,10 +179,10 @@ inline void backlog_queue_t::push_get(endpoint_impl_t* endpoint, int rank,
   lock.unlock();
 }
 
-inline void backlog_queue_t::push_fetch_add(endpoint_impl_t* endpoint, int rank,
-                                            uint64_t* result, mr_t result_mr,
-                                            uint64_t value, uint64_t offset,
-                                            rmr_t rmr, void* user_context)
+inline void backlog_queue_t::push_fetch_add(
+    endpoint_impl_t* endpoint, int rank, uint64_t* result, mr_t result_mr,
+    uint64_t value, uint64_t offset, rmr_t rmr,
+    net_atomic_scope_t required_atomic_scope, void* user_context)
 {
   LCI_PCOUNTER_ADD(backlog_queue_push, 1);
   backlog_queue_entry_t entry;
@@ -194,6 +194,7 @@ inline void backlog_queue_t::push_fetch_add(endpoint_impl_t* endpoint, int rank,
   entry.value = value;
   entry.offset = offset;
   entry.rmr = rmr;
+  entry.required_atomic_scope = required_atomic_scope;
   entry.user_context = user_context;
 
   nentries_per_rank[rank].val.fetch_add(1, std::memory_order_relaxed);
@@ -205,7 +206,9 @@ inline void backlog_queue_t::push_fetch_add(endpoint_impl_t* endpoint, int rank,
 
 inline void backlog_queue_t::push_add(endpoint_impl_t* endpoint, int rank,
                                       uint64_t value, uint64_t offset,
-                                      rmr_t rmr, void* user_context)
+                                      rmr_t rmr,
+                                      net_atomic_scope_t required_atomic_scope,
+                                      void* user_context)
 {
   LCI_PCOUNTER_ADD(backlog_queue_push, 1);
   backlog_queue_entry_t entry;
@@ -215,6 +218,7 @@ inline void backlog_queue_t::push_add(endpoint_impl_t* endpoint, int rank,
   entry.value = value;
   entry.offset = offset;
   entry.rmr = rmr;
+  entry.required_atomic_scope = required_atomic_scope;
   entry.user_context = user_context;
 
   nentries_per_rank[rank].val.fetch_add(1, std::memory_order_relaxed);
@@ -279,12 +283,13 @@ inline bool backlog_queue_t::progress()
     case backlog_op_t::fetch_add:
       error = entry.endpoint->post_fetch_add(
           entry.rank, static_cast<uint64_t*>(entry.buffer), entry.mr,
-          entry.value, entry.offset, entry.rmr, entry.user_context, true, true);
+          entry.value, entry.offset, entry.rmr, entry.required_atomic_scope,
+          entry.user_context, true, true);
       break;
     case backlog_op_t::add:
-      error =
-          entry.endpoint->post_add(entry.rank, entry.value, entry.offset,
-                                   entry.rmr, entry.user_context, true, true);
+      error = entry.endpoint->post_add(entry.rank, entry.value, entry.offset,
+                                       entry.rmr, entry.required_atomic_scope,
+                                       entry.user_context, true, true);
       break;
     default:
       LCI_Assert(false, "Unknown operation %d\n", entry.op);

--- a/src/backlog_queue/backlog_queue_inline.hpp
+++ b/src/backlog_queue/backlog_queue_inline.hpp
@@ -179,6 +179,51 @@ inline void backlog_queue_t::push_get(endpoint_impl_t* endpoint, int rank,
   lock.unlock();
 }
 
+inline void backlog_queue_t::push_fetch_add(endpoint_impl_t* endpoint, int rank,
+                                            uint64_t* result, mr_t result_mr,
+                                            uint64_t value, uint64_t offset,
+                                            rmr_t rmr, void* user_context)
+{
+  LCI_PCOUNTER_ADD(backlog_queue_push, 1);
+  backlog_queue_entry_t entry;
+  entry.op = backlog_op_t::fetch_add;
+  entry.endpoint = endpoint;
+  entry.rank = rank;
+  entry.buffer = result;
+  entry.mr = result_mr;
+  entry.value = value;
+  entry.offset = offset;
+  entry.rmr = rmr;
+  entry.user_context = user_context;
+
+  nentries_per_rank[rank].val.fetch_add(1, std::memory_order_relaxed);
+  lock.lock();
+  backlog_queue.push(entry);
+  set_empty(false);
+  lock.unlock();
+}
+
+inline void backlog_queue_t::push_add(endpoint_impl_t* endpoint, int rank,
+                                      uint64_t value, uint64_t offset,
+                                      rmr_t rmr, void* user_context)
+{
+  LCI_PCOUNTER_ADD(backlog_queue_push, 1);
+  backlog_queue_entry_t entry;
+  entry.op = backlog_op_t::add;
+  entry.endpoint = endpoint;
+  entry.rank = rank;
+  entry.value = value;
+  entry.offset = offset;
+  entry.rmr = rmr;
+  entry.user_context = user_context;
+
+  nentries_per_rank[rank].val.fetch_add(1, std::memory_order_relaxed);
+  lock.lock();
+  backlog_queue.push(entry);
+  set_empty(false);
+  lock.unlock();
+}
+
 inline bool backlog_queue_t::progress()
 {
   if (is_empty()) {
@@ -230,6 +275,16 @@ inline bool backlog_queue_t::progress()
       error = entry.endpoint->post_get(entry.rank, entry.buffer, entry.size,
                                        entry.mr, entry.offset, entry.rmr,
                                        entry.user_context, true, true);
+      break;
+    case backlog_op_t::fetch_add:
+      error = entry.endpoint->post_fetch_add(
+          entry.rank, static_cast<uint64_t*>(entry.buffer), entry.mr,
+          entry.value, entry.offset, entry.rmr, entry.user_context, true, true);
+      break;
+    case backlog_op_t::add:
+      error =
+          entry.endpoint->post_add(entry.rank, entry.value, entry.offset,
+                                   entry.rmr, entry.user_context, true, true);
       break;
     default:
       LCI_Assert(false, "Unknown operation %d\n", entry.op);

--- a/src/backlog_queue/backlog_queue_inline.hpp
+++ b/src/backlog_queue/backlog_queue_inline.hpp
@@ -316,6 +316,25 @@ inline bool backlog_queue_t::progress()
   return did_something;
 }
 
+inline size_t backlog_queue_t::abort()
+{
+  lock.lock();
+  size_t aborted = 0;
+  while (!backlog_queue.empty()) {
+    const backlog_queue_entry_t entry = backlog_queue.front();
+    backlog_queue.pop();
+    nentries_per_rank[entry.rank].val.fetch_sub(1, std::memory_order_relaxed);
+    if (entry.op == backlog_op_t::sends || entry.op == backlog_op_t::puts ||
+        entry.op == backlog_op_t::putImms) {
+      free(entry.buffer);
+    }
+    ++aborted;
+  }
+  set_empty(true);
+  lock.unlock();
+  return aborted;
+}
+
 }  // namespace lci
 
 #endif  // LCI_BACKLOG_QUEUE_INLINE_HPP

--- a/src/binding/input/network.py
+++ b/src/binding/input/network.py
@@ -23,7 +23,7 @@ resource_net_context := resource(
         attr_enum("ibv_odp_strategy", enum_options=["none", "explicit_odp", "implicit_odp"], default_value="none", comment="For the IBV backend: the on-demand paging strategy."),
         attr_enum("ibv_prefetch_strategy", enum_options=["none", "prefetch", "prefetch_write", "prefetch_no_fault"], default_value="none", comment="For the IBV backend: the mr prefetch strategy."),
         attr("bool", "support_putimm", inout_trait="out", comment="Whether the network context supports put with immediate data."),
-        attr("bool", "support_uint64_fetch_add", inout_trait="out", comment="Whether the network context supports uint64 fetch-add and add."),
+        attr("net_atomic_scope_t", "atomic_scope", inout_trait="out", comment="The scope guaranteed for uint64 network fetch-add and add. NONE means unavailable; HCA is not global atomicity."),
         attr("bool", "use_dmabuf", default_value=1, comment="Whether to use dmabuf for cuda buffer registration."),
     ],
     doc = {
@@ -322,6 +322,7 @@ operation(
         positional_arg("uint64_t", "value", comment="The value to add to the remote uint64."),
         positional_arg("uint64_t", "offset", comment="The 8-byte-aligned offset of the remote uint64 from the remote region base."),
         positional_arg("rmr_t", "rmr", comment="The remote memory region handle."),
+        optional_arg("net_atomic_scope_t", "required_atomic_scope", "net_atomic_scope_t::GLOBAL", comment="The minimum atomic scope required by the caller. HCA must be requested explicitly when it is sufficient."),
         optional_arg("device_t", "device", "runtime.get_impl()->default_device", comment="The device to use."),
         optional_arg("endpoint_t", "endpoint", "device.get_impl()->default_endpoint", comment="The endpoint to use."),
         optional_arg("void*", "user_context", "nullptr", comment="The arbitrary user-defined context."),
@@ -330,7 +331,7 @@ operation(
     doc = {
         "in_group": "LCI_NET",
         "brief": "Post a uint64 network fetch-add operation.",
-        "details": "This operation is available only when @ref net_context_attr_t::support_uint64_fetch_add is true. The result storage and remote address must both be 8-byte aligned. The completion is reported through @ref net_poll_cq as @ref net_opcode_t::FETCH_ADD. Operations posted to the same rank through the same endpoint preserve the backend's native queue-pair ordering."
+        "details": "This operation requires at least @p required_atomic_scope; the default is @ref net_atomic_scope_t::GLOBAL, so an @ref net_atomic_scope_t::HCA capability must be accepted explicitly by callers whose algorithm permits it. The result storage and remote address must both be 8-byte aligned, and @p rmr must not be empty. The completion is reported through @ref net_poll_cq as @ref net_opcode_t::FETCH_ADD. Operations posted to the same rank through the same endpoint preserve the backend's native queue-pair ordering."
     }
 ),
 operation(
@@ -341,6 +342,7 @@ operation(
         positional_arg("uint64_t", "value", comment="The value to add to the remote uint64."),
         positional_arg("uint64_t", "offset", comment="The 8-byte-aligned offset of the remote uint64 from the remote region base."),
         positional_arg("rmr_t", "rmr", comment="The remote memory region handle."),
+        optional_arg("net_atomic_scope_t", "required_atomic_scope", "net_atomic_scope_t::GLOBAL", comment="The minimum atomic scope required by the caller. HCA must be requested explicitly when it is sufficient."),
         optional_arg("device_t", "device", "runtime.get_impl()->default_device", comment="The device to use."),
         optional_arg("endpoint_t", "endpoint", "device.get_impl()->default_endpoint", comment="The endpoint to use."),
         optional_arg("void*", "user_context", "nullptr", comment="The arbitrary user-defined context."),
@@ -349,7 +351,7 @@ operation(
     doc = {
         "in_group": "LCI_NET",
         "brief": "Post a uint64 network add operation.",
-        "details": "This convenience operation discards the previous remote value in backend-managed registered storage. It is available only when @ref net_context_attr_t::support_uint64_fetch_add is true. The completion is reported through @ref net_poll_cq as @ref net_opcode_t::FETCH_ADD. Operations posted to the same rank through the same endpoint preserve the backend's native queue-pair ordering."
+        "details": "This convenience operation discards the previous remote value in backend-managed registered storage. It requires at least @p required_atomic_scope; the default is @ref net_atomic_scope_t::GLOBAL, so an @ref net_atomic_scope_t::HCA capability must be accepted explicitly by callers whose algorithm permits it. @p rmr must not be empty and its target address must be 8-byte aligned. The completion is reported through @ref net_poll_cq as @ref net_opcode_t::FETCH_ADD. Operations posted to the same rank through the same endpoint preserve the backend's native queue-pair ordering."
     }
 ),
 ]

--- a/src/binding/input/network.py
+++ b/src/binding/input/network.py
@@ -23,6 +23,7 @@ resource_net_context := resource(
         attr_enum("ibv_odp_strategy", enum_options=["none", "explicit_odp", "implicit_odp"], default_value="none", comment="For the IBV backend: the on-demand paging strategy."),
         attr_enum("ibv_prefetch_strategy", enum_options=["none", "prefetch", "prefetch_write", "prefetch_no_fault"], default_value="none", comment="For the IBV backend: the mr prefetch strategy."),
         attr("bool", "support_putimm", inout_trait="out", comment="Whether the network context supports put with immediate data."),
+        attr("bool", "support_uint64_fetch_add", inout_trait="out", comment="Whether the network context supports uint64 fetch-add and add."),
         attr("bool", "use_dmabuf", default_value=1, comment="Whether to use dmabuf for cuda buffer registration."),
     ],
     doc = {
@@ -309,6 +310,46 @@ operation(
         "in_group": "LCI_NET",
         "brief": "Post a network get operation.",
         "details": "This operation uses the *post* semantics: means the operation is posted and not completed immediately; the completed operation will be reported through @ref net_poll_cq; the receive buffer can only be read after the operation is completed."
+    }
+),
+operation(
+    "net_post_fetch_add",
+    [
+        optional_runtime_args,
+        positional_arg("int", "rank", comment="The target rank."),
+        positional_arg("uint64_t*", "result", comment="The aligned local result storage for the previous remote value."),
+        positional_arg("mr_t", "result_mr", comment="The registered memory region containing @p result."),
+        positional_arg("uint64_t", "value", comment="The value to add to the remote uint64."),
+        positional_arg("uint64_t", "offset", comment="The 8-byte-aligned offset of the remote uint64 from the remote region base."),
+        positional_arg("rmr_t", "rmr", comment="The remote memory region handle."),
+        optional_arg("device_t", "device", "runtime.get_impl()->default_device", comment="The device to use."),
+        optional_arg("endpoint_t", "endpoint", "device.get_impl()->default_endpoint", comment="The endpoint to use."),
+        optional_arg("void*", "user_context", "nullptr", comment="The arbitrary user-defined context."),
+        return_val("error_t", "error", comment="The error code."),
+    ],
+    doc = {
+        "in_group": "LCI_NET",
+        "brief": "Post a uint64 network fetch-add operation.",
+        "details": "This operation is available only when @ref net_context_attr_t::support_uint64_fetch_add is true. The result storage and remote address must both be 8-byte aligned. The completion is reported through @ref net_poll_cq as @ref net_opcode_t::FETCH_ADD. Operations posted to the same rank through the same endpoint preserve the backend's native queue-pair ordering."
+    }
+),
+operation(
+    "net_post_add",
+    [
+        optional_runtime_args,
+        positional_arg("int", "rank", comment="The target rank."),
+        positional_arg("uint64_t", "value", comment="The value to add to the remote uint64."),
+        positional_arg("uint64_t", "offset", comment="The 8-byte-aligned offset of the remote uint64 from the remote region base."),
+        positional_arg("rmr_t", "rmr", comment="The remote memory region handle."),
+        optional_arg("device_t", "device", "runtime.get_impl()->default_device", comment="The device to use."),
+        optional_arg("endpoint_t", "endpoint", "device.get_impl()->default_endpoint", comment="The endpoint to use."),
+        optional_arg("void*", "user_context", "nullptr", comment="The arbitrary user-defined context."),
+        return_val("error_t", "error", comment="The error code."),
+    ],
+    doc = {
+        "in_group": "LCI_NET",
+        "brief": "Post a uint64 network add operation.",
+        "details": "This convenience operation discards the previous remote value in backend-managed registered storage. It is available only when @ref net_context_attr_t::support_uint64_fetch_add is true. The completion is reported through @ref net_poll_cq as @ref net_opcode_t::FETCH_ADD. Operations posted to the same rank through the same endpoint preserve the backend's native queue-pair ordering."
     }
 ),
 ]

--- a/src/core/lci.cpp
+++ b/src/core/lci.cpp
@@ -20,7 +20,7 @@ const char* get_errorcode_str(errorcode_t errorcode)
 const char* get_net_opcode_str(net_opcode_t opcode)
 {
   static const char opcode_str[][16] = {
-      "SEND", "RECV", "WRITE", "REMOTE_WRITE", "READ", "ERROR",
+      "SEND", "RECV", "WRITE", "REMOTE_WRITE", "READ", "FETCH_ADD", "ERROR",
   };
   return opcode_str[static_cast<int>(opcode)];
 }

--- a/src/core/lci.cpp
+++ b/src/core/lci.cpp
@@ -20,7 +20,8 @@ const char* get_errorcode_str(errorcode_t errorcode)
 const char* get_net_opcode_str(net_opcode_t opcode)
 {
   static const char opcode_str[][16] = {
-      "SEND", "RECV", "WRITE", "REMOTE_WRITE", "READ", "ERROR", "FETCH_ADD",
+      "SEND", "RECV",  "WRITE",     "REMOTE_WRITE",
+      "READ", "ERROR", "FETCH_ADD", "FETCH_ADD_ERROR",
   };
   return opcode_str[static_cast<int>(opcode)];
 }

--- a/src/core/lci.cpp
+++ b/src/core/lci.cpp
@@ -20,7 +20,7 @@ const char* get_errorcode_str(errorcode_t errorcode)
 const char* get_net_opcode_str(net_opcode_t opcode)
 {
   static const char opcode_str[][16] = {
-      "SEND", "RECV", "WRITE", "REMOTE_WRITE", "READ", "FETCH_ADD", "ERROR",
+      "SEND", "RECV", "WRITE", "REMOTE_WRITE", "READ", "ERROR", "FETCH_ADD",
   };
   return opcode_str[static_cast<int>(opcode)];
 }

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -256,13 +256,8 @@ void process_completion_batch(runtime_t runtime, device_t device,
     const net_status_t& status = statuses[i];
     if (status.opcode == net_opcode_t::ERROR) {
       device.get_impl()->mark_network_failed();
-      const bool is_raw_atomic_failure =
-          status.failed_opcode == net_opcode_t::FETCH_ADD;
-      const int failed_rank =
-          is_raw_atomic_failure ? status.rank : get_failed_peer_rank(status);
-      if (!is_raw_atomic_failure) {
-        cleanup_failed_simple_operation(status);
-      }
+      const int failed_rank = get_failed_peer_rank(status);
+      cleanup_failed_simple_operation(status);
       if (!has_failure) {
         has_failure = true;
         first_failure_has_rank = failed_rank >= 0;

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -274,6 +274,10 @@ void process_completion_batch(runtime_t runtime, device_t device,
       progress_remote_write(runtime, status);
     } else if (status.opcode == net_opcode_t::READ) {
       progress_read(status);
+    } else if (status.opcode == net_opcode_t::FETCH_ADD) {
+      // Fetch-add is currently a raw network API. Its result and user context
+      // belong to the caller of net_poll_cq(), while the IBV backend has
+      // already retired its discard storage and pending-operation accounting.
     }
   }
   if (has_failure) {

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -256,8 +256,13 @@ void process_completion_batch(runtime_t runtime, device_t device,
     const net_status_t& status = statuses[i];
     if (status.opcode == net_opcode_t::ERROR) {
       device.get_impl()->mark_network_failed();
-      const int failed_rank = get_failed_peer_rank(status);
-      cleanup_failed_simple_operation(status);
+      const bool is_raw_atomic_failure =
+          status.failed_opcode == net_opcode_t::FETCH_ADD;
+      const int failed_rank =
+          is_raw_atomic_failure ? status.rank : get_failed_peer_rank(status);
+      if (!is_raw_atomic_failure) {
+        cleanup_failed_simple_operation(status);
+      }
       if (!has_failure) {
         has_failure = true;
         first_failure_has_rank = failed_rank >= 0;

--- a/src/core/progress.cpp
+++ b/src/core/progress.cpp
@@ -254,10 +254,17 @@ void process_completion_batch(runtime_t runtime, device_t device,
   int first_failed_rank = -1;
   for (size_t i = 0; i < count; i++) {
     const net_status_t& status = statuses[i];
-    if (status.opcode == net_opcode_t::ERROR) {
+    const bool is_atomic_failure =
+        status.opcode == net_opcode_t::FETCH_ADD_ERROR;
+    if (status.opcode == net_opcode_t::ERROR || is_atomic_failure) {
       device.get_impl()->mark_network_failed();
-      const int failed_rank = get_failed_peer_rank(status);
-      cleanup_failed_simple_operation(status);
+      // Atomic user contexts belong to raw network callers, not LCI. Do not
+      // interpret or reclaim them while reporting a device failure.
+      const int failed_rank =
+          is_atomic_failure ? status.rank : get_failed_peer_rank(status);
+      if (!is_atomic_failure) {
+        cleanup_failed_simple_operation(status);
+      }
       if (!has_failure) {
         has_failure = true;
         first_failure_has_rank = failed_rank >= 0;

--- a/src/monitor/performance_counter.hpp
+++ b/src/monitor/performance_counter.hpp
@@ -35,6 +35,9 @@ extern LCT_pcounter_ctx_t pcounter_ctx;
     _macro(net_read_post)                   \
     _macro(net_read_post_retry)             \
     _macro(net_read_comp)                   \
+    _macro(net_atomic_post)                 \
+    _macro(net_atomic_post_retry)           \
+    _macro(net_atomic_comp)                 \
     _macro(net_remote_write_comp)           \
     _macro(packet_get)                      \
     _macro(packet_get_retry)                \

--- a/src/network/device_inline.hpp
+++ b/src/network/device_inline.hpp
@@ -14,14 +14,16 @@ inline size_t device_impl_t::poll_comp(net_status_t* p_statuses,
              "max_polls must be no larger than %lu\n", LCI_BACKEND_MAX_POLLS);
   size_t ret = poll_comp_impl(p_statuses, max_polls);
   LCI_PCOUNTER_ADD(net_poll_cq_entry_count, ret);
-  for (size_t i = 0; i < ret; i++) {
-    [[maybe_unused]] auto& status = p_statuses[i];
-    LCI_DBG_Log(
-        LOG_TRACE, "network",
-        "poll_comp %lu/%lu opcode %s user_context %p length %lu imm_data %x "
-        "rank %d\n",
-        i + 1, ret, get_net_opcode_str(status.opcode), status.user_context,
-        status.length, status.imm_data, status.rank);
+  if (p_statuses != nullptr) {
+    for (size_t i = 0; i < ret; i++) {
+      [[maybe_unused]] auto& status = p_statuses[i];
+      LCI_DBG_Log(
+          LOG_TRACE, "network",
+          "poll_comp %lu/%lu opcode %s user_context %p length %lu imm_data "
+          "%x rank %d\n",
+          i + 1, ret, get_net_opcode_str(status.opcode), status.user_context,
+          status.length, status.imm_data, status.rank);
+    }
   }
   return ret;
 }

--- a/src/network/endpoint_inline.hpp
+++ b/src/network/endpoint_inline.hpp
@@ -6,10 +6,27 @@
 
 namespace lci
 {
+inline bool is_valid_uint64_atomic_scope(net_atomic_scope_t available_scope,
+                                         net_atomic_scope_t required_scope)
+{
+  switch (required_scope) {
+    case net_atomic_scope_t::HCA:
+      return available_scope == net_atomic_scope_t::HCA ||
+             available_scope == net_atomic_scope_t::GLOBAL;
+    case net_atomic_scope_t::GLOBAL:
+      return available_scope == net_atomic_scope_t::GLOBAL;
+    case net_atomic_scope_t::NONE:
+      return false;
+    default:
+      return false;
+  }
+}
+
 inline bool is_valid_uint64_atomic_remote_address(uint64_t offset, rmr_t rmr)
 {
   constexpr size_t ATOMIC_SIZE = sizeof(uint64_t);
-  if (rmr.base % ATOMIC_SIZE != 0 || offset % ATOMIC_SIZE != 0) {
+  if (rmr.is_empty() || rmr.base % ATOMIC_SIZE != 0 ||
+      offset % ATOMIC_SIZE != 0) {
     return false;
   }
   return offset <= std::numeric_limits<uintptr_t>::max() - rmr.base;
@@ -337,17 +354,28 @@ inline error_t endpoint_impl_t::post_get(int rank, void* buffer, size_t size,
 
 inline error_t endpoint_impl_t::post_fetch_add(
     int rank, uint64_t* result, mr_t result_mr, uint64_t value, uint64_t offset,
-    rmr_t rmr, void* user_context, bool allow_retry, bool force_post)
+    rmr_t rmr, net_atomic_scope_t required_atomic_scope, void* user_context,
+    bool allow_retry, bool force_post)
 {
-  if (!net_context_attr.support_uint64_fetch_add) {
+  if (!is_valid_uint64_atomic_scope(net_context_attr.atomic_scope,
+                                    required_atomic_scope)) {
     LCI_Warn(
-        "uint64 network fetch-add is unsupported by the selected backend\n");
+        "uint64 network fetch-add requires atomic scope %d, but the selected "
+        "backend reports scope %d\n",
+        static_cast<int>(required_atomic_scope),
+        static_cast<int>(net_context_attr.atomic_scope));
     return errorcode_t::fatal;
   }
   if (!is_valid_uint64_atomic_result(result, result_mr, device)) {
     LCI_Warn(
         "uint64 network fetch-add requires an aligned 8-byte result within "
         "a memory region registered on the endpoint device\n");
+    return errorcode_t::fatal;
+  }
+  if (rmr.is_empty()) {
+    LCI_Warn(
+        "uint64 network fetch-add requires a non-empty remote memory "
+        "region\n");
     return errorcode_t::fatal;
   }
   if (!is_valid_uint64_atomic_remote_address(offset, rmr)) {
@@ -375,7 +403,7 @@ inline error_t endpoint_impl_t::post_fetch_add(
     LCI_PCOUNTER_ADD(net_atomic_post_retry, 1);
     if (!allow_retry) {
       backlog_queue.push_fetch_add(this, rank, result, result_mr, value, offset,
-                                   rmr, user_context);
+                                   rmr, required_atomic_scope, user_context);
       error = errorcode_t::posted_backlog;
     }
   } else if (error.is_posted()) {
@@ -384,20 +412,31 @@ inline error_t endpoint_impl_t::post_fetch_add(
   LCI_DBG_Log(
       LOG_TRACE, "network",
       "post_fetch_add rank %d result %p result_mr %p value %lu offset %lu "
-      "rmr %p user_context %p allow_retry %d force_post %d return %s\n",
+      "rmr %p required_atomic_scope %d user_context %p allow_retry %d "
+      "force_post %d return %s\n",
       rank, result, result_mr.p_impl, value, offset,
-      reinterpret_cast<void*>(rmr.base), user_context, allow_retry, force_post,
-      error.get_str());
+      reinterpret_cast<void*>(rmr.base),
+      static_cast<int>(required_atomic_scope), user_context, allow_retry,
+      force_post, error.get_str());
   return error;
 }
 
-inline error_t endpoint_impl_t::post_add(int rank, uint64_t value,
-                                         uint64_t offset, rmr_t rmr,
-                                         void* user_context, bool allow_retry,
-                                         bool force_post)
+inline error_t endpoint_impl_t::post_add(
+    int rank, uint64_t value, uint64_t offset, rmr_t rmr,
+    net_atomic_scope_t required_atomic_scope, void* user_context,
+    bool allow_retry, bool force_post)
 {
-  if (!net_context_attr.support_uint64_fetch_add) {
-    LCI_Warn("uint64 network add is unsupported by the selected backend\n");
+  if (!is_valid_uint64_atomic_scope(net_context_attr.atomic_scope,
+                                    required_atomic_scope)) {
+    LCI_Warn(
+        "uint64 network add requires atomic scope %d, but the selected "
+        "backend reports scope %d\n",
+        static_cast<int>(required_atomic_scope),
+        static_cast<int>(net_context_attr.atomic_scope));
+    return errorcode_t::fatal;
+  }
+  if (rmr.is_empty()) {
+    LCI_Warn("uint64 network add requires a non-empty remote memory region\n");
     return errorcode_t::fatal;
   }
   if (!is_valid_uint64_atomic_remote_address(offset, rmr)) {
@@ -422,17 +461,20 @@ inline error_t endpoint_impl_t::post_add(int rank, uint64_t value,
   if (error.is_retry()) {
     LCI_PCOUNTER_ADD(net_atomic_post_retry, 1);
     if (!allow_retry) {
-      backlog_queue.push_add(this, rank, value, offset, rmr, user_context);
+      backlog_queue.push_add(this, rank, value, offset, rmr,
+                             required_atomic_scope, user_context);
       error = errorcode_t::posted_backlog;
     }
   } else if (error.is_posted()) {
     LCI_PCOUNTER_ADD(net_atomic_post, 1);
   }
   LCI_DBG_Log(LOG_TRACE, "network",
-              "post_add rank %d value %lu offset %lu rmr %p user_context %p "
-              "allow_retry %d force_post %d return %s\n",
+              "post_add rank %d value %lu offset %lu rmr %p "
+              "required_atomic_scope %d user_context %p allow_retry %d "
+              "force_post %d return %s\n",
               rank, value, offset, reinterpret_cast<void*>(rmr.base),
-              user_context, allow_retry, force_post, error.get_str());
+              static_cast<int>(required_atomic_scope), user_context,
+              allow_retry, force_post, error.get_str());
   return error;
 }
 

--- a/src/network/endpoint_inline.hpp
+++ b/src/network/endpoint_inline.hpp
@@ -6,6 +6,35 @@
 
 namespace lci
 {
+inline bool is_valid_uint64_atomic_remote_address(uint64_t offset, rmr_t rmr)
+{
+  constexpr size_t ATOMIC_SIZE = sizeof(uint64_t);
+  if (rmr.base % ATOMIC_SIZE != 0 || offset % ATOMIC_SIZE != 0) {
+    return false;
+  }
+  return offset <= std::numeric_limits<uintptr_t>::max() - rmr.base;
+}
+
+inline bool is_valid_uint64_atomic_result(uint64_t* result, mr_t result_mr,
+                                          device_t device)
+{
+  constexpr size_t ATOMIC_SIZE = sizeof(uint64_t);
+  if (result == nullptr || result_mr.is_empty()) {
+    return false;
+  }
+  mr_impl_t* result_mr_impl = result_mr.get_impl();
+  if (!(result_mr_impl->device == device)) {
+    return false;
+  }
+  uintptr_t result_address = reinterpret_cast<uintptr_t>(result);
+  uintptr_t mr_address = reinterpret_cast<uintptr_t>(result_mr_impl->address);
+  if (result_address % ATOMIC_SIZE != 0 || result_address < mr_address ||
+      result_mr_impl->size < ATOMIC_SIZE) {
+    return false;
+  }
+  return result_address - mr_address <= result_mr_impl->size - ATOMIC_SIZE;
+}
+
 inline error_t endpoint_impl_t::post_sends(int rank, void* buffer, size_t size,
                                            net_imm_data_t imm_data,
                                            void* user_context, bool allow_retry,
@@ -303,6 +332,107 @@ inline error_t endpoint_impl_t::post_get(int rank, void* buffer, size_t size,
               "user_context %p allow_retry %d force_post %d return %s\n",
               rank, buffer, size, mr.get_impl(), offset, rmr.base, user_context,
               allow_retry, force_post, error.get_str());
+  return error;
+}
+
+inline error_t endpoint_impl_t::post_fetch_add(
+    int rank, uint64_t* result, mr_t result_mr, uint64_t value, uint64_t offset,
+    rmr_t rmr, void* user_context, bool allow_retry, bool force_post)
+{
+  if (!net_context_attr.support_uint64_fetch_add) {
+    LCI_Warn(
+        "uint64 network fetch-add is unsupported by the selected backend\n");
+    return errorcode_t::fatal;
+  }
+  if (!is_valid_uint64_atomic_result(result, result_mr, device)) {
+    LCI_Warn(
+        "uint64 network fetch-add requires an aligned 8-byte result within "
+        "a memory region registered on the endpoint device\n");
+    return errorcode_t::fatal;
+  }
+  if (!is_valid_uint64_atomic_remote_address(offset, rmr)) {
+    LCI_Warn(
+        "uint64 network fetch-add requires an aligned 8-byte remote "
+        "address\n");
+    return errorcode_t::fatal;
+  }
+
+  error_t error;
+  if (!force_post && !backlog_queue.is_empty(rank)) {
+    error = errorcode_t::retry_backlog;
+  } else {
+    bool high_priority = !allow_retry || force_post;
+    // Account before handing the WQE to a backend because another thread may
+    // poll and complete it before this function returns.
+    add_backend_pending_ops();
+    error = post_fetch_add_impl(rank, result, result_mr, value, offset, rmr,
+                                user_context, high_priority);
+    if (!error.is_posted()) {
+      sub_backend_pending_ops();
+    }
+  }
+  if (error.is_retry()) {
+    LCI_PCOUNTER_ADD(net_atomic_post_retry, 1);
+    if (!allow_retry) {
+      backlog_queue.push_fetch_add(this, rank, result, result_mr, value, offset,
+                                   rmr, user_context);
+      error = errorcode_t::posted_backlog;
+    }
+  } else if (error.is_posted()) {
+    LCI_PCOUNTER_ADD(net_atomic_post, 1);
+  }
+  LCI_DBG_Log(
+      LOG_TRACE, "network",
+      "post_fetch_add rank %d result %p result_mr %p value %lu offset %lu "
+      "rmr %p user_context %p allow_retry %d force_post %d return %s\n",
+      rank, result, result_mr.p_impl, value, offset,
+      reinterpret_cast<void*>(rmr.base), user_context, allow_retry, force_post,
+      error.get_str());
+  return error;
+}
+
+inline error_t endpoint_impl_t::post_add(int rank, uint64_t value,
+                                         uint64_t offset, rmr_t rmr,
+                                         void* user_context, bool allow_retry,
+                                         bool force_post)
+{
+  if (!net_context_attr.support_uint64_fetch_add) {
+    LCI_Warn("uint64 network add is unsupported by the selected backend\n");
+    return errorcode_t::fatal;
+  }
+  if (!is_valid_uint64_atomic_remote_address(offset, rmr)) {
+    LCI_Warn("uint64 network add requires an aligned 8-byte remote address\n");
+    return errorcode_t::fatal;
+  }
+
+  error_t error;
+  if (!force_post && !backlog_queue.is_empty(rank)) {
+    error = errorcode_t::retry_backlog;
+  } else {
+    bool high_priority = !allow_retry || force_post;
+    // See post_fetch_add() for why this is incremented before the backend
+    // posts the work request.
+    add_backend_pending_ops();
+    error =
+        post_add_impl(rank, value, offset, rmr, user_context, high_priority);
+    if (!error.is_posted()) {
+      sub_backend_pending_ops();
+    }
+  }
+  if (error.is_retry()) {
+    LCI_PCOUNTER_ADD(net_atomic_post_retry, 1);
+    if (!allow_retry) {
+      backlog_queue.push_add(this, rank, value, offset, rmr, user_context);
+      error = errorcode_t::posted_backlog;
+    }
+  } else if (error.is_posted()) {
+    LCI_PCOUNTER_ADD(net_atomic_post, 1);
+  }
+  LCI_DBG_Log(LOG_TRACE, "network",
+              "post_add rank %d value %lu offset %lu rmr %p user_context %p "
+              "allow_retry %d force_post %d return %s\n",
+              rank, value, offset, reinterpret_cast<void*>(rmr.base),
+              user_context, allow_retry, force_post, error.get_str());
   return error;
 }
 

--- a/src/network/ibv/backend_ibv.cpp
+++ b/src/network/ibv/backend_ibv.cpp
@@ -464,10 +464,7 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
     atomic_trackers.reserve(nranks);
     for (size_t rank = 0; rank < nranks; ++rank) {
       auto tracker = std::make_unique<ibv_atomic_tracker_t>();
-      tracker->free_discard_slots.reserve(slots_per_rank);
-      for (size_t slot = 0; slot < slots_per_rank; ++slot) {
-        tracker->free_discard_slots.push_back(rank * slots_per_rank + slot);
-      }
+      tracker->initialize(slots_per_rank, rank * slots_per_rank);
       atomic_trackers.emplace_back(std::move(tracker));
     }
   }
@@ -654,11 +651,9 @@ ibv_endpoint_impl_t::~ibv_endpoint_impl_t()
     abort_atomic_operations();
   } else {
     for (auto& tracker : atomic_trackers) {
-      tracker->lock.lock();
-      LCI_Assert(tracker->posted_ops.empty(),
+      LCI_Assert(tracker->empty(),
                  "Destroying endpoint with outstanding uint64 fetch-add "
                  "operations\n");
-      tracker->lock.unlock();
     }
   }
   p_ibv_device->qp2rank_map.remove_qps(ib_qps);

--- a/src/network/ibv/backend_ibv.cpp
+++ b/src/network/ibv/backend_ibv.cpp
@@ -71,25 +71,42 @@ ibv_net_context_impl_t::ibv_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   // query device attribute
   int rc = ibv_query_device(ib_context, &ib_dev_attr);
   LCI_Assert(rc == 0, "Unable to query device\n");
+  attr.support_uint64_fetch_add = ib_dev_attr.atomic_cap != IBV_ATOMIC_NONE;
+  if (!attr.support_uint64_fetch_add) {
+    LCI_Log(LOG_INFO, "ibv",
+            "The selected device does not support uint64 fetch-add\n");
+  }
 
   rc = ibv_query_device_ex(ib_context, nullptr, &ib_dev_attrx);
   LCI_Assert(rc == 0, "Unable to query device for its extended features\n");
 
   // configure on-demand paging
   ib_odp_mr = nullptr;
+  const uint32_t rc_odp_caps =
+      ib_dev_attrx.odp_caps.per_transport_caps.rc_odp_caps;
+  if (attr.support_uint64_fetch_add &&
+      attr.ibv_odp_strategy != attr_ibv_odp_strategy_t::none &&
+      !(rc_odp_caps & IBV_ODP_SUPPORT_ATOMIC)) {
+    LCI_Warn(
+        "The selected device does not support ODP atomic operations; "
+        "disabling uint64 fetch-add for this ODP configuration\n");
+    attr.support_uint64_fetch_add = false;
+  }
   if (attr.ibv_odp_strategy == attr_ibv_odp_strategy_t::implicit_odp) {
     const uint32_t rc_caps_mask = IBV_ODP_SUPPORT_SEND | IBV_ODP_SUPPORT_RECV |
                                   IBV_ODP_SUPPORT_WRITE | IBV_ODP_SUPPORT_READ |
                                   IBV_ODP_SUPPORT_SRQ_RECV;
     LCI_Assert((ib_dev_attrx.odp_caps.general_caps & IBV_ODP_SUPPORT) &&
-                   ((ib_dev_attrx.odp_caps.per_transport_caps.rc_odp_caps &
-                     rc_caps_mask) == rc_caps_mask),
+                   ((rc_odp_caps & rc_caps_mask) == rc_caps_mask),
                "The device isn't ODP capable\n");
     LCI_Assert(ib_dev_attrx.odp_caps.general_caps & IBV_ODP_SUPPORT_IMPLICIT,
                "The device doesn't support implicit ODP\n");
-    ib_odp_mr = ibv_reg_mr(ib_pd, nullptr, SIZE_MAX,
-                           IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
-                               IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_ON_DEMAND);
+    int odp_mr_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+                       IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_ON_DEMAND;
+    if (attr.support_uint64_fetch_add) {
+      odp_mr_flags |= IBV_ACCESS_REMOTE_ATOMIC;
+    }
+    ib_odp_mr = ibv_reg_mr(ib_pd, nullptr, SIZE_MAX, odp_mr_flags);
     LCI_Assert(ib_odp_mr, "Couldn't register MR for ODP\n");
   }
 
@@ -273,6 +290,9 @@ mr_t ibv_device_impl_t::register_memory_impl(void* buffer, size_t size)
       mr_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                  IBV_ACCESS_REMOTE_WRITE;
     }
+    if (net_context_attr.support_uint64_fetch_add) {
+      mr_flags |= IBV_ACCESS_REMOTE_ATOMIC;
+    }
 #if defined(LCI_USE_CUDA) || defined(LCI_USE_HIP)
     mr->acc_attr = accelerator::get_buffer_attr(buffer);
     mr->dmabuf_fd = -1;
@@ -386,6 +406,36 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
     slot.val.store(static_cast<int>(device_attr.net_max_sends),
                    std::memory_order_relaxed);
   }
+  if (net_context_attr.support_uint64_fetch_add) {
+    const size_t nranks = static_cast<size_t>(get_rank_n());
+    const size_t slots_per_rank = device_attr.net_max_sends;
+    LCI_Assert(slots_per_rank > 0,
+               "uint64 fetch-add requires at least one send slot\n");
+    LCI_Assert(
+        nranks <= std::numeric_limits<size_t>::max() / slots_per_rank,
+        "Too many ranks/send slots for uint64 fetch-add discard storage\n");
+    const size_t nslots = nranks * slots_per_rank;
+    LCI_Assert(nslots <= std::numeric_limits<size_t>::max() / sizeof(uint64_t),
+               "uint64 fetch-add discard storage size overflow\n");
+    atomic_discard_buffers.resize(nslots);
+    atomic_discard_mr = p_ibv_device->register_memory_impl(
+        atomic_discard_buffers.data(), nslots * sizeof(uint64_t));
+    // Discard storage belongs to this endpoint and must bypass the registration
+    // cache so its backing vector can be released with the endpoint.
+    atomic_discard_mr.p_impl->device = device;
+    atomic_discard_mr.p_impl->address = atomic_discard_buffers.data();
+    atomic_discard_mr.p_impl->size = nslots * sizeof(uint64_t);
+    atomic_discard_mr.p_impl->mr_base = atomic_discard_buffers.data();
+    atomic_trackers.reserve(nranks);
+    for (size_t rank = 0; rank < nranks; ++rank) {
+      auto tracker = std::make_unique<ibv_atomic_tracker_t>();
+      tracker->free_discard_slots.reserve(slots_per_rank);
+      for (size_t slot = 0; slot < slots_per_rank; ++slot) {
+        tracker->free_discard_slots.push_back(rank * slots_per_rank + slot);
+      }
+      atomic_trackers.emplace_back(std::move(tracker));
+    }
+  }
 
   if (device_attr.ibv_td_strategy == attr_ibv_td_strategy_t::per_qp) {
     ib_qp_extras.resize(get_rank_n());
@@ -458,7 +508,7 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
               qp_attr.cap.max_inline_data, net_context_attr.max_inject_size);
     }
   }
-  p_ibv_device->qp2rank_map.add_qps(ib_qps, &qp_remaining_slots);
+  p_ibv_device->qp2rank_map.add_qps(ib_qps, &qp_remaining_slots, this);
 
   // Modify QP states to INIT
   struct bootstrap_data_t {
@@ -476,6 +526,9 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
     mod_attr.qp_state = IBV_QPS_INIT;
     mod_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                                IBV_ACCESS_REMOTE_WRITE;
+    if (net_context_attr.support_uint64_fetch_add) {
+      mod_attr.qp_access_flags |= IBV_ACCESS_REMOTE_ATOMIC;
+    }
     mod_attr.pkey_index = 0;
     mod_attr.port_num = p_net_context->ib_dev_port;
 
@@ -562,6 +615,13 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
 
 ibv_endpoint_impl_t::~ibv_endpoint_impl_t()
 {
+  for (auto& tracker : atomic_trackers) {
+    tracker->lock.lock();
+    LCI_Assert(tracker->posted_ops.empty(),
+               "Destroying endpoint with outstanding uint64 fetch-add "
+               "operations\n");
+    tracker->lock.unlock();
+  }
   p_ibv_device->qp2rank_map.remove_qps(ib_qps);
   for (auto* qp : ib_qps) {
     if (qp != nullptr) {
@@ -577,6 +637,10 @@ ibv_endpoint_impl_t::~ibv_endpoint_impl_t()
         --g_td_num;
       }
     }
+  }
+  if (!atomic_discard_mr.is_empty()) {
+    p_ibv_device->deregister_memory_impl(atomic_discard_mr.p_impl);
+    atomic_discard_mr.p_impl = nullptr;
   }
 }
 

--- a/src/network/ibv/backend_ibv.cpp
+++ b/src/network/ibv/backend_ibv.cpp
@@ -29,6 +29,36 @@ const char* mtu_str(enum ibv_mtu mtu)
       return "invalid MTU";
   }
 }
+
+net_atomic_scope_t get_atomic_scope(enum ibv_atomic_cap atomic_cap)
+{
+  switch (atomic_cap) {
+    case IBV_ATOMIC_NONE:
+      return net_atomic_scope_t::NONE;
+    case IBV_ATOMIC_HCA:
+      return net_atomic_scope_t::HCA;
+    case IBV_ATOMIC_GLOB:
+      return net_atomic_scope_t::GLOBAL;
+    default:
+      LCI_Warn("Unknown IBV atomic capability %d; disabling uint64 fetch-add\n",
+               static_cast<int>(atomic_cap));
+      return net_atomic_scope_t::NONE;
+  }
+}
+
+const char* atomic_scope_str(net_atomic_scope_t scope)
+{
+  switch (scope) {
+    case net_atomic_scope_t::NONE:
+      return "NONE";
+    case net_atomic_scope_t::HCA:
+      return "HCA";
+    case net_atomic_scope_t::GLOBAL:
+      return "GLOBAL";
+    default:
+      return "invalid";
+  }
+}
 }  // namespace
 
 //
@@ -71,10 +101,15 @@ ibv_net_context_impl_t::ibv_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   // query device attribute
   int rc = ibv_query_device(ib_context, &ib_dev_attr);
   LCI_Assert(rc == 0, "Unable to query device\n");
-  attr.support_uint64_fetch_add = ib_dev_attr.atomic_cap != IBV_ATOMIC_NONE;
-  if (!attr.support_uint64_fetch_add) {
+  attr.atomic_scope = get_atomic_scope(ib_dev_attr.atomic_cap);
+  if (attr.atomic_scope == net_atomic_scope_t::NONE) {
     LCI_Log(LOG_INFO, "ibv",
             "The selected device does not support uint64 fetch-add\n");
+  } else {
+    LCI_Log(LOG_INFO, "ibv",
+            "The selected device reports %s uint64 atomic "
+            "scope\n",
+            atomic_scope_str(attr.atomic_scope));
   }
 
   rc = ibv_query_device_ex(ib_context, nullptr, &ib_dev_attrx);
@@ -84,13 +119,13 @@ ibv_net_context_impl_t::ibv_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   ib_odp_mr = nullptr;
   const uint32_t rc_odp_caps =
       ib_dev_attrx.odp_caps.per_transport_caps.rc_odp_caps;
-  if (attr.support_uint64_fetch_add &&
+  if (attr.atomic_scope != net_atomic_scope_t::NONE &&
       attr.ibv_odp_strategy != attr_ibv_odp_strategy_t::none &&
       !(rc_odp_caps & IBV_ODP_SUPPORT_ATOMIC)) {
     LCI_Warn(
         "The selected device does not support ODP atomic operations; "
         "disabling uint64 fetch-add for this ODP configuration\n");
-    attr.support_uint64_fetch_add = false;
+    attr.atomic_scope = net_atomic_scope_t::NONE;
   }
   if (attr.ibv_odp_strategy == attr_ibv_odp_strategy_t::implicit_odp) {
     const uint32_t rc_caps_mask = IBV_ODP_SUPPORT_SEND | IBV_ODP_SUPPORT_RECV |
@@ -103,7 +138,7 @@ ibv_net_context_impl_t::ibv_net_context_impl_t(runtime_t runtime_, attr_t attr_)
                "The device doesn't support implicit ODP\n");
     int odp_mr_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                        IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_ON_DEMAND;
-    if (attr.support_uint64_fetch_add) {
+    if (attr.atomic_scope != net_atomic_scope_t::NONE) {
       odp_mr_flags |= IBV_ACCESS_REMOTE_ATOMIC;
     }
     ib_odp_mr = ibv_reg_mr(ib_pd, nullptr, SIZE_MAX, odp_mr_flags);
@@ -290,7 +325,7 @@ mr_t ibv_device_impl_t::register_memory_impl(void* buffer, size_t size)
       mr_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                  IBV_ACCESS_REMOTE_WRITE;
     }
-    if (net_context_attr.support_uint64_fetch_add) {
+    if (net_context_attr.atomic_scope != net_atomic_scope_t::NONE) {
       mr_flags |= IBV_ACCESS_REMOTE_ATOMIC;
     }
 #if defined(LCI_USE_CUDA) || defined(LCI_USE_HIP)
@@ -406,7 +441,7 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
     slot.val.store(static_cast<int>(device_attr.net_max_sends),
                    std::memory_order_relaxed);
   }
-  if (net_context_attr.support_uint64_fetch_add) {
+  if (net_context_attr.atomic_scope != net_atomic_scope_t::NONE) {
     const size_t nranks = static_cast<size_t>(get_rank_n());
     const size_t slots_per_rank = device_attr.net_max_sends;
     LCI_Assert(slots_per_rank > 0,
@@ -526,7 +561,7 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
     mod_attr.qp_state = IBV_QPS_INIT;
     mod_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
                                IBV_ACCESS_REMOTE_WRITE;
-    if (net_context_attr.support_uint64_fetch_add) {
+    if (net_context_attr.atomic_scope != net_atomic_scope_t::NONE) {
       mod_attr.qp_access_flags |= IBV_ACCESS_REMOTE_ATOMIC;
     }
     mod_attr.pkey_index = 0;
@@ -615,12 +650,16 @@ ibv_endpoint_impl_t::ibv_endpoint_impl_t(device_t device_, attr_t attr_)
 
 ibv_endpoint_impl_t::~ibv_endpoint_impl_t()
 {
-  for (auto& tracker : atomic_trackers) {
-    tracker->lock.lock();
-    LCI_Assert(tracker->posted_ops.empty(),
-               "Destroying endpoint with outstanding uint64 fetch-add "
-               "operations\n");
-    tracker->lock.unlock();
+  if (p_ibv_device->has_network_failed()) {
+    abort_atomic_operations();
+  } else {
+    for (auto& tracker : atomic_trackers) {
+      tracker->lock.lock();
+      LCI_Assert(tracker->posted_ops.empty(),
+                 "Destroying endpoint with outstanding uint64 fetch-add "
+                 "operations\n");
+      tracker->lock.unlock();
+    }
   }
   p_ibv_device->qp2rank_map.remove_qps(ib_qps);
   for (auto* qp : ib_qps) {

--- a/src/network/ibv/backend_ibv.hpp
+++ b/src/network/ibv/backend_ibv.hpp
@@ -7,6 +7,7 @@
 #include "infiniband/verbs.h"
 #include <atomic>
 #include <algorithm>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -33,6 +34,8 @@
 
 namespace lci
 {
+class ibv_endpoint_impl_t;
+
 class ibv_net_context_impl_t : public lci::net_context_impl_t
 {
  public:
@@ -75,6 +78,7 @@ class qp2rank_map_t
   struct entry_t {
     int rank = -1;
     padded_atomic_t<int>* slots = nullptr;
+    ibv_endpoint_impl_t* endpoint = nullptr;
   };
 
   struct snapshot_t {
@@ -92,7 +96,8 @@ class qp2rank_map_t
   }
 
   void add_qps(const std::vector<struct ibv_qp*>& qps,
-               std::vector<padded_atomic_t<int>>* qp_slots);
+               std::vector<padded_atomic_t<int>>* qp_slots,
+               ibv_endpoint_impl_t* endpoint);
   void remove_qps(const std::vector<struct ibv_qp*>& qps);
   snapshot_t* get_snapshot()
   {
@@ -137,6 +142,17 @@ class ibv_device_impl_t : public lci::device_impl_t
   LCIU_CACHE_PADDING(sizeof(spinlock_t));
 };
 
+struct ibv_atomic_op_t {
+  bool uses_discard;
+  size_t discard_slot;
+};
+
+struct ibv_atomic_tracker_t {
+  spinlock_t lock;
+  std::vector<size_t> free_discard_slots;
+  std::deque<ibv_atomic_op_t> posted_ops;
+};
+
 class ibv_endpoint_impl_t : public lci::endpoint_impl_t
 {
  public:
@@ -163,11 +179,20 @@ class ibv_endpoint_impl_t : public lci::endpoint_impl_t
   error_t post_get_impl(int rank, void* buffer, size_t size, mr_t mr,
                         uint64_t offset, rmr_t rmr, void* user_context,
                         bool high_priority) override;
+  error_t post_fetch_add_impl(int rank, uint64_t* result, mr_t result_mr,
+                              uint64_t value, uint64_t offset, rmr_t rmr,
+                              void* user_context, bool high_priority) override;
+  error_t post_add_impl(int rank, uint64_t value, uint64_t offset, rmr_t rmr,
+                        void* user_context, bool high_priority) override;
+  void complete_atomic_operation(int rank);
 
   ibv_device_impl_t* p_ibv_device;
   std::vector<struct ibv_qp*> ib_qps;
   std::vector<LCISI_ibv_qp_extra_t> ib_qp_extras;
   std::vector<padded_atomic_t<int>> qp_remaining_slots;
+  std::vector<uint64_t> atomic_discard_buffers;
+  mr_t atomic_discard_mr;
+  std::vector<std::unique_ptr<ibv_atomic_tracker_t>> atomic_trackers;
   spinlock_t qps_lock;
 
  private:
@@ -175,6 +200,9 @@ class ibv_endpoint_impl_t : public lci::endpoint_impl_t
   void unlock_qp(int rank);
   bool try_acquire_slot(int rank, bool high_priority);
   void release_slot(int rank);
+  error_t prepare_atomic_operation(int rank, bool uses_discard,
+                                   size_t* discard_slot);
+  void cancel_atomic_operation(int rank);
 };
 
 }  // namespace lci

--- a/src/network/ibv/backend_ibv.hpp
+++ b/src/network/ibv/backend_ibv.hpp
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <algorithm>
 #include <cstdint>
-#include <list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -144,17 +143,30 @@ class ibv_device_impl_t : public lci::device_impl_t
 };
 
 struct ibv_atomic_op_t {
-  bool uses_discard;
-  size_t discard_slot;
-  void* user_context;
+  bool active = false;
+  bool uses_discard = false;
+  size_t discard_slot = 0;
+  void* user_context = nullptr;
 };
 
 struct ibv_atomic_tracker_t {
   spinlock_t lock;
   std::vector<size_t> free_discard_slots;
-  std::list<ibv_atomic_op_t> posted_ops;
+  std::vector<size_t> free_record_slots;
+  std::vector<ibv_atomic_op_t> records;
+  size_t active_records = 0;
 
+  void initialize(size_t record_count, size_t first_discard_slot);
+  error_t prepare(bool uses_discard, void* user_context, size_t* discard_slot,
+                  uintptr_t* wr_id);
+  bool cancel(uintptr_t wr_id);
+  bool complete(uintptr_t wr_id, void** user_context);
+  bool empty();
   size_t abort();
+
+ private:
+  ibv_atomic_op_t* get_active_record_locked(uintptr_t wr_id);
+  void release_record_locked(ibv_atomic_op_t* op);
 };
 
 class ibv_endpoint_impl_t : public lci::endpoint_impl_t

--- a/src/network/ibv/backend_ibv.hpp
+++ b/src/network/ibv/backend_ibv.hpp
@@ -7,7 +7,8 @@
 #include "infiniband/verbs.h"
 #include <atomic>
 #include <algorithm>
-#include <deque>
+#include <cstdint>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -145,12 +146,15 @@ class ibv_device_impl_t : public lci::device_impl_t
 struct ibv_atomic_op_t {
   bool uses_discard;
   size_t discard_slot;
+  void* user_context;
 };
 
 struct ibv_atomic_tracker_t {
   spinlock_t lock;
   std::vector<size_t> free_discard_slots;
-  std::deque<ibv_atomic_op_t> posted_ops;
+  std::list<ibv_atomic_op_t> posted_ops;
+
+  size_t abort();
 };
 
 class ibv_endpoint_impl_t : public lci::endpoint_impl_t
@@ -184,7 +188,9 @@ class ibv_endpoint_impl_t : public lci::endpoint_impl_t
                               void* user_context, bool high_priority) override;
   error_t post_add_impl(int rank, uint64_t value, uint64_t offset, rmr_t rmr,
                         void* user_context, bool high_priority) override;
-  void complete_atomic_operation(int rank);
+  bool complete_atomic_operation(int rank, uintptr_t wr_id,
+                                 void** user_context);
+  void abort_atomic_operations();
 
   ibv_device_impl_t* p_ibv_device;
   std::vector<struct ibv_qp*> ib_qps;
@@ -201,8 +207,9 @@ class ibv_endpoint_impl_t : public lci::endpoint_impl_t
   bool try_acquire_slot(int rank, bool high_priority);
   void release_slot(int rank);
   error_t prepare_atomic_operation(int rank, bool uses_discard,
-                                   size_t* discard_slot);
-  void cancel_atomic_operation(int rank);
+                                   void* user_context, size_t* discard_slot,
+                                   uintptr_t* wr_id);
+  void cancel_atomic_operation(int rank, uintptr_t wr_id);
 };
 
 }  // namespace lci

--- a/src/network/ibv/backend_ibv_inline.hpp
+++ b/src/network/ibv/backend_ibv_inline.hpp
@@ -159,17 +159,13 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       if (wcs[i].status != IBV_WC_SUCCESS) {
         status.opcode = net_opcode_t::ERROR;
         status.rank = is_receive ? -1 : entry.rank;
-        if (is_atomic) {
-          status.user_context = atomic_user_context;
-          status.failed_opcode = net_opcode_t::FETCH_ADD;
-        } else if (wcs[i].opcode == IBV_WC_FETCH_ADD) {
-          // This should not happen for LCI-posted atomics, but never expose a
-          // raw atomic wr_id as an arbitrary user context.
+        if (is_atomic || wcs[i].opcode == IBV_WC_FETCH_ADD) {
+          // Raw atomic contexts are not internal_context_t instances. Never
+          // expose one through a generic error completion, which progress()
+          // is allowed to inspect as an LCI-owned context.
           status.user_context = nullptr;
-          status.failed_opcode = net_opcode_t::FETCH_ADD;
         } else {
           status.user_context = is_receive ? nullptr : (void*)wcs[i].wr_id;
-          status.failed_opcode = net_opcode_t::ERROR;
         }
       } else if (is_atomic) {
         status.opcode = net_opcode_t::FETCH_ADD;
@@ -193,13 +189,11 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
         status.opcode = net_opcode_t::WRITE;
         status.user_context = (void*)wcs[i].wr_id;
       } else if (wcs[i].opcode == IBV_WC_FETCH_ADD) {
-        // LCI always records a posted atomic before handing it to ibverbs.
-        // Preserve the raw-operation distinction if the tracker was already
-        // torn down instead of treating its wr_id as user-owned storage.
+        // A tracked atomic completion is always handled above. If the tracker
+        // was already torn down, report only the generic completion failure.
         status.opcode = net_opcode_t::ERROR;
         status.rank = entry.rank;
         status.user_context = nullptr;
-        status.failed_opcode = net_opcode_t::FETCH_ADD;
       } else {
         LCI_Assert(wcs[i].opcode == IBV_WC_RDMA_READ,
                    "Unexpected IBV opcode!\n");
@@ -317,47 +311,16 @@ inline error_t ibv_endpoint_impl_t::prepare_atomic_operation(
     int rank, bool uses_discard, void* user_context, size_t* discard_slot,
     uintptr_t* wr_id)
 {
-  ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
-  if (!tracker.lock.try_lock()) {
-    return errorcode_t::retry_lock;
-  }
-  if (uses_discard && tracker.free_discard_slots.empty()) {
-    tracker.lock.unlock();
-    return errorcode_t::retry_nomem;
-  }
-  size_t slot = 0;
-  if (uses_discard) {
-    slot = tracker.free_discard_slots.back();
-    tracker.free_discard_slots.pop_back();
-  }
-  tracker.posted_ops.push_back({uses_discard, slot, user_context});
-  *wr_id = reinterpret_cast<uintptr_t>(&tracker.posted_ops.back());
-  tracker.lock.unlock();
-  if (discard_slot) {
-    *discard_slot = slot;
-  }
-  return errorcode_t::done;
+  return atomic_trackers[rank]->prepare(uses_discard, user_context,
+                                        discard_slot, wr_id);
 }
 
 inline void ibv_endpoint_impl_t::cancel_atomic_operation(int rank,
                                                          uintptr_t wr_id)
 {
-  ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
-  tracker.lock.lock();
-  auto it = std::find_if(tracker.posted_ops.begin(), tracker.posted_ops.end(),
-                         [wr_id](const ibv_atomic_op_t& op) {
-                           return reinterpret_cast<uintptr_t>(&op) == wr_id;
-                         });
-  if (it == tracker.posted_ops.end()) {
-    tracker.lock.unlock();
+  if (!atomic_trackers[rank]->cancel(wr_id)) {
     LCI_Warn("No atomic operation to cancel for rank %d\n", rank);
-    return;
   }
-  if (it->uses_discard) {
-    tracker.free_discard_slots.push_back(it->discard_slot);
-  }
-  tracker.posted_ops.erase(it);
-  tracker.lock.unlock();
 }
 
 inline bool ibv_endpoint_impl_t::complete_atomic_operation(int rank,
@@ -367,39 +330,137 @@ inline bool ibv_endpoint_impl_t::complete_atomic_operation(int rank,
   if (atomic_trackers.empty()) {
     return false;
   }
-  ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
-  tracker.lock.lock();
-  auto it = std::find_if(tracker.posted_ops.begin(), tracker.posted_ops.end(),
-                         [wr_id](const ibv_atomic_op_t& op) {
-                           return reinterpret_cast<uintptr_t>(&op) == wr_id;
-                         });
-  if (it == tracker.posted_ops.end()) {
-    tracker.lock.unlock();
-    return false;
-  }
-  if (user_context) {
-    *user_context = it->user_context;
-  }
-  if (it->uses_discard) {
-    tracker.free_discard_slots.push_back(it->discard_slot);
-  }
-  tracker.posted_ops.erase(it);
-  tracker.lock.unlock();
+  if (!atomic_trackers[rank]->complete(wr_id, user_context)) return false;
   sub_backend_pending_ops();
   LCI_PCOUNTER_ADD(net_atomic_comp, 1);
   return true;
 }
 
+inline void ibv_atomic_tracker_t::initialize(size_t record_count,
+                                             size_t first_discard_slot)
+{
+  LCI_Assert(records.empty() && free_record_slots.empty() &&
+                 free_discard_slots.empty(),
+             "IBV atomic tracker was initialized twice\n");
+  records.resize(record_count);
+  free_record_slots.reserve(record_count);
+  free_discard_slots.reserve(record_count);
+  for (size_t i = 0; i < record_count; ++i) {
+    free_record_slots.push_back(i);
+    free_discard_slots.push_back(first_discard_slot + i);
+  }
+}
+
+inline ibv_atomic_op_t* ibv_atomic_tracker_t::get_active_record_locked(
+    uintptr_t wr_id)
+{
+  if (records.empty()) return nullptr;
+  const uintptr_t begin = reinterpret_cast<uintptr_t>(records.data());
+  if (wr_id < begin) return nullptr;
+  const uintptr_t offset = wr_id - begin;
+  if (offset % sizeof(ibv_atomic_op_t) != 0) return nullptr;
+  const size_t index = offset / sizeof(ibv_atomic_op_t);
+  if (index >= records.size()) return nullptr;
+  ibv_atomic_op_t* op = &records[index];
+  return op->active ? op : nullptr;
+}
+
+inline void ibv_atomic_tracker_t::release_record_locked(ibv_atomic_op_t* op)
+{
+  LCI_DBG_Assert(op != nullptr && op->active,
+                 "Releasing an inactive IBV atomic tracker record\n");
+  if (op->uses_discard) {
+    free_discard_slots.push_back(op->discard_slot);
+  }
+  const size_t index = static_cast<size_t>(op - records.data());
+  *op = ibv_atomic_op_t{};
+  free_record_slots.push_back(index);
+  --active_records;
+}
+
+inline error_t ibv_atomic_tracker_t::prepare(bool uses_discard,
+                                             void* user_context,
+                                             size_t* discard_slot,
+                                             uintptr_t* wr_id)
+{
+  if (!lock.try_lock()) return errorcode_t::retry_lock;
+  if (free_record_slots.empty() ||
+      (uses_discard && free_discard_slots.empty())) {
+    lock.unlock();
+    return errorcode_t::retry_nomem;
+  }
+  const size_t record_index = free_record_slots.back();
+  free_record_slots.pop_back();
+  ibv_atomic_op_t& op = records[record_index];
+  LCI_DBG_Assert(!op.active, "IBV atomic tracker record is already active\n");
+  op.active = true;
+  op.uses_discard = uses_discard;
+  op.user_context = user_context;
+  if (uses_discard) {
+    op.discard_slot = free_discard_slots.back();
+    free_discard_slots.pop_back();
+  }
+  ++active_records;
+  *wr_id = reinterpret_cast<uintptr_t>(&op);
+  if (discard_slot) {
+    *discard_slot = op.discard_slot;
+  }
+  lock.unlock();
+  return errorcode_t::done;
+}
+
+inline bool ibv_atomic_tracker_t::cancel(uintptr_t wr_id)
+{
+  lock.lock();
+  ibv_atomic_op_t* op = get_active_record_locked(wr_id);
+  if (op == nullptr) {
+    lock.unlock();
+    return false;
+  }
+  release_record_locked(op);
+  lock.unlock();
+  return true;
+}
+
+inline bool ibv_atomic_tracker_t::complete(uintptr_t wr_id, void** user_context)
+{
+  lock.lock();
+  ibv_atomic_op_t* op = get_active_record_locked(wr_id);
+  if (op == nullptr) {
+    lock.unlock();
+    return false;
+  }
+  if (user_context) {
+    *user_context = op->user_context;
+  }
+  release_record_locked(op);
+  lock.unlock();
+  return true;
+}
+
+inline bool ibv_atomic_tracker_t::empty()
+{
+  lock.lock();
+  const bool is_empty = active_records == 0;
+  lock.unlock();
+  return is_empty;
+}
+
 inline size_t ibv_atomic_tracker_t::abort()
 {
   lock.lock();
-  const size_t aborted = posted_ops.size();
-  for (const ibv_atomic_op_t& op : posted_ops) {
-    if (op.uses_discard) {
-      free_discard_slots.push_back(op.discard_slot);
+  const size_t aborted = active_records;
+  if (aborted != 0) {
+    free_record_slots.clear();
+    for (size_t i = 0; i < records.size(); ++i) {
+      if (records[i].active && records[i].uses_discard) {
+        free_discard_slots.push_back(records[i].discard_slot);
+      }
+      records[i] = ibv_atomic_op_t{};
+      free_record_slots.push_back(i);
     }
+    active_records = 0;
   }
-  posted_ops.clear();
   lock.unlock();
   return aborted;
 }

--- a/src/network/ibv/backend_ibv_inline.hpp
+++ b/src/network/ibv/backend_ibv_inline.hpp
@@ -7,14 +7,16 @@
 namespace lci
 {
 inline void qp2rank_map_t::add_qps(const std::vector<struct ibv_qp*>& qps,
-                                   std::vector<padded_atomic_t<int>>* qp_slots)
+                                   std::vector<padded_atomic_t<int>>* qp_slots,
+                                   ibv_endpoint_impl_t* endpoint)
 {
-  if (qps.empty() || qp_slots == nullptr) return;
+  if (qps.empty() || qp_slots == nullptr || endpoint == nullptr) return;
   std::unique_lock<std::shared_mutex> lock(mutex);
   for (size_t i = 0; i < qps.size(); ++i) {
     entry_t entry;
     entry.rank = static_cast<int>(i);
     entry.slots = &(*qp_slots)[i];
+    entry.endpoint = endpoint;
     qp_entries.emplace_back(qps[i]->qp_num, entry);
   }
   rebuild_locked();
@@ -119,6 +121,7 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       qp2rank_map_t::entry_t entry = snapshot->get_entry(wcs[i].qp_num);
       const bool is_receive = wcs[i].opcode == IBV_WC_RECV ||
                               wcs[i].opcode == IBV_WC_RECV_RDMA_WITH_IMM;
+      const bool is_fetch_add = wcs[i].opcode == IBV_WC_FETCH_ADD;
       // A failed send-side completion still releases its SQ slot.
       if (!is_receive) {
         if (entry.rank >= 0 && entry.rank < get_rank_n() &&
@@ -134,6 +137,14 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
               "Completion for qp_num %u does not map to an active endpoint\n",
               wcs[i].qp_num);
         }
+      }
+      if (is_fetch_add) {
+        LCI_Assert(entry.endpoint != nullptr && entry.rank >= 0 &&
+                       entry.rank < get_rank_n(),
+                   "Fetch-add completion for qp_num %u does not map to an "
+                   "active endpoint\n",
+                   wcs[i].qp_num);
+        entry.endpoint->complete_atomic_operation(entry.rank);
       }
       if (!p_statuses) continue;
       net_status_t& status = p_statuses[i];
@@ -158,6 +169,9 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
         status.user_context = (void*)wcs[i].wr_id;
       } else if (wcs[i].opcode == IBV_WC_RDMA_WRITE) {
         status.opcode = net_opcode_t::WRITE;
+        status.user_context = (void*)wcs[i].wr_id;
+      } else if (is_fetch_add) {
+        status.opcode = net_opcode_t::FETCH_ADD;
         status.user_context = (void*)wcs[i].wr_id;
       } else {
         LCI_Assert(wcs[i].opcode == IBV_WC_RDMA_READ,
@@ -270,6 +284,60 @@ inline bool ibv_endpoint_impl_t::try_acquire_slot(int rank, bool high_priority)
 inline void ibv_endpoint_impl_t::release_slot(int rank)
 {
   qp_remaining_slots[rank].val.fetch_add(1, std::memory_order_relaxed);
+}
+
+inline error_t ibv_endpoint_impl_t::prepare_atomic_operation(
+    int rank, bool uses_discard, size_t* discard_slot)
+{
+  ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
+  if (!tracker.lock.try_lock()) {
+    return errorcode_t::retry_lock;
+  }
+  if (uses_discard && tracker.free_discard_slots.empty()) {
+    tracker.lock.unlock();
+    return errorcode_t::retry_nomem;
+  }
+  size_t slot = 0;
+  if (uses_discard) {
+    slot = tracker.free_discard_slots.back();
+    tracker.free_discard_slots.pop_back();
+  }
+  tracker.posted_ops.push_back({uses_discard, slot});
+  tracker.lock.unlock();
+  if (discard_slot) {
+    *discard_slot = slot;
+  }
+  return errorcode_t::done;
+}
+
+inline void ibv_endpoint_impl_t::cancel_atomic_operation(int rank)
+{
+  ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
+  tracker.lock.lock();
+  LCI_DBG_Assert(!tracker.posted_ops.empty(),
+                 "No atomic operation to cancel for rank %d\n", rank);
+  ibv_atomic_op_t op = tracker.posted_ops.back();
+  tracker.posted_ops.pop_back();
+  if (op.uses_discard) {
+    tracker.free_discard_slots.push_back(op.discard_slot);
+  }
+  tracker.lock.unlock();
+}
+
+inline void ibv_endpoint_impl_t::complete_atomic_operation(int rank)
+{
+  ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
+  tracker.lock.lock();
+  LCI_Assert(!tracker.posted_ops.empty(),
+             "No atomic operation to complete for rank %d\n", rank);
+  ibv_atomic_op_t op = tracker.posted_ops.front();
+  tracker.posted_ops.pop_front();
+  if (op.uses_discard) {
+    tracker.free_discard_slots.push_back(op.discard_slot);
+  }
+  tracker.lock.unlock();
+  sub_backend_pending_ops();
+  LCI_PCOUNTER_ADD(net_atomic_comp, 1);
 }
 
 inline bool ibv_endpoint_impl_t::try_lock_qp(int rank)
@@ -648,6 +716,111 @@ inline error_t ibv_endpoint_impl_t::post_get_impl(int rank, void* buffer,
     release_slot(rank);
     return errorcode_t::retry_nomem;  // exceed send queue capacity
   } else {
+    release_slot(rank);
+    IBV_SAFECALL_RET(ret);
+  }
+}
+
+inline error_t ibv_endpoint_impl_t::post_fetch_add_impl(
+    int rank, uint64_t* result, mr_t result_mr, uint64_t value, uint64_t offset,
+    rmr_t rmr, void* user_context, bool high_priority)
+{
+  static_assert(sizeof(uint64_t) == 8,
+                "IBV fetch-add requires an 8-byte uint64_t");
+  struct ibv_sge list = {};
+  list.addr = reinterpret_cast<uintptr_t>(result);
+  list.length = sizeof(uint64_t);
+  list.lkey = ibv_detail::get_mr_lkey(result_mr);
+
+  struct ibv_send_wr wr = {};
+  wr.wr_id = reinterpret_cast<uintptr_t>(user_context);
+  wr.sg_list = &list;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.wr.atomic.remote_addr = rmr.base + offset;
+  wr.wr.atomic.rkey = rmr.opaque_rkey;
+  wr.wr.atomic.compare_add = value;
+
+  if (!try_acquire_slot(rank, high_priority)) {
+    return errorcode_t::retry_nomem;
+  }
+  if (!try_lock_qp(rank)) {
+    release_slot(rank);
+    return errorcode_t::retry_lock;
+  }
+  error_t tracking_error = prepare_atomic_operation(rank, false, nullptr);
+  if (tracking_error.is_retry()) {
+    unlock_qp(rank);
+    release_slot(rank);
+    return tracking_error;
+  }
+  struct ibv_send_wr* bad_wr;
+  int ret = ibv_post_send(ib_qps[rank], &wr, &bad_wr);
+  unlock_qp(rank);
+  if (ret == 0) {
+    return errorcode_t::posted;
+  } else if (ret == ENOMEM) {
+    cancel_atomic_operation(rank);
+    release_slot(rank);
+    return errorcode_t::retry_nomem;
+  } else {
+    cancel_atomic_operation(rank);
+    release_slot(rank);
+    IBV_SAFECALL_RET(ret);
+  }
+}
+
+inline error_t ibv_endpoint_impl_t::post_add_impl(int rank, uint64_t value,
+                                                  uint64_t offset, rmr_t rmr,
+                                                  void* user_context,
+                                                  bool high_priority)
+{
+  static_assert(sizeof(uint64_t) == 8,
+                "IBV fetch-add requires an 8-byte uint64_t");
+
+  if (!try_acquire_slot(rank, high_priority)) {
+    return errorcode_t::retry_nomem;
+  }
+  if (!try_lock_qp(rank)) {
+    release_slot(rank);
+    return errorcode_t::retry_lock;
+  }
+  size_t discard_slot = 0;
+  error_t tracking_error = prepare_atomic_operation(rank, true, &discard_slot);
+  if (tracking_error.is_retry()) {
+    unlock_qp(rank);
+    release_slot(rank);
+    return tracking_error;
+  }
+
+  struct ibv_sge list = {};
+  list.addr =
+      reinterpret_cast<uintptr_t>(&atomic_discard_buffers[discard_slot]);
+  list.length = sizeof(uint64_t);
+  list.lkey = ibv_detail::get_mr_lkey(atomic_discard_mr);
+
+  struct ibv_send_wr wr = {};
+  wr.wr_id = reinterpret_cast<uintptr_t>(user_context);
+  wr.sg_list = &list;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.wr.atomic.remote_addr = rmr.base + offset;
+  wr.wr.atomic.rkey = rmr.opaque_rkey;
+  wr.wr.atomic.compare_add = value;
+
+  struct ibv_send_wr* bad_wr;
+  int ret = ibv_post_send(ib_qps[rank], &wr, &bad_wr);
+  unlock_qp(rank);
+  if (ret == 0) {
+    return errorcode_t::posted;
+  } else if (ret == ENOMEM) {
+    cancel_atomic_operation(rank);
+    release_slot(rank);
+    return errorcode_t::retry_nomem;
+  } else {
+    cancel_atomic_operation(rank);
     release_slot(rank);
     IBV_SAFECALL_RET(ret);
   }

--- a/src/network/ibv/backend_ibv_inline.hpp
+++ b/src/network/ibv/backend_ibv_inline.hpp
@@ -121,7 +121,6 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       qp2rank_map_t::entry_t entry = snapshot->get_entry(wcs[i].qp_num);
       const bool is_receive = wcs[i].opcode == IBV_WC_RECV ||
                               wcs[i].opcode == IBV_WC_RECV_RDMA_WITH_IMM;
-      const bool is_fetch_add = wcs[i].opcode == IBV_WC_FETCH_ADD;
       // A failed send-side completion still releases its SQ slot.
       if (!is_receive) {
         if (entry.rank >= 0 && entry.rank < get_rank_n() &&
@@ -138,13 +137,21 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
               wcs[i].qp_num);
         }
       }
-      if (is_fetch_add) {
-        LCI_Assert(entry.endpoint != nullptr && entry.rank >= 0 &&
-                       entry.rank < get_rank_n(),
-                   "Fetch-add completion for qp_num %u does not map to an "
-                   "active endpoint\n",
-                   wcs[i].qp_num);
-        entry.endpoint->complete_atomic_operation(entry.rank);
+      void* atomic_user_context = nullptr;
+      bool is_atomic = false;
+      if (!is_receive &&
+          (wcs[i].opcode == IBV_WC_FETCH_ADD ||
+           wcs[i].status != IBV_WC_SUCCESS) &&
+          entry.endpoint != nullptr && entry.rank >= 0 &&
+          entry.rank < get_rank_n()) {
+        // Atomic WQEs use an internal tracker record for wr_id. Look that
+        // record up before interpreting wr_id so a raw atomic user_context is
+        // never cast as an internal context on an error completion.
+        is_atomic = entry.endpoint->complete_atomic_operation(
+            entry.rank, wcs[i].wr_id, &atomic_user_context);
+      }
+      if (wcs[i].status != IBV_WC_SUCCESS) {
+        mark_network_failed();
       }
       if (!p_statuses) continue;
       net_status_t& status = p_statuses[i];
@@ -152,7 +159,22 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       if (wcs[i].status != IBV_WC_SUCCESS) {
         status.opcode = net_opcode_t::ERROR;
         status.rank = is_receive ? -1 : entry.rank;
-        status.user_context = is_receive ? nullptr : (void*)wcs[i].wr_id;
+        if (is_atomic) {
+          status.user_context = atomic_user_context;
+          status.failed_opcode = net_opcode_t::FETCH_ADD;
+        } else if (wcs[i].opcode == IBV_WC_FETCH_ADD) {
+          // This should not happen for LCI-posted atomics, but never expose a
+          // raw atomic wr_id as an arbitrary user context.
+          status.user_context = nullptr;
+          status.failed_opcode = net_opcode_t::FETCH_ADD;
+        } else {
+          status.user_context = is_receive ? nullptr : (void*)wcs[i].wr_id;
+          status.failed_opcode = net_opcode_t::ERROR;
+        }
+      } else if (is_atomic) {
+        status.opcode = net_opcode_t::FETCH_ADD;
+        status.rank = entry.rank;
+        status.user_context = atomic_user_context;
       } else if (wcs[i].opcode == IBV_WC_RECV) {
         status.opcode = net_opcode_t::RECV;
         status.user_context = (void*)wcs[i].wr_id;
@@ -170,9 +192,14 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       } else if (wcs[i].opcode == IBV_WC_RDMA_WRITE) {
         status.opcode = net_opcode_t::WRITE;
         status.user_context = (void*)wcs[i].wr_id;
-      } else if (is_fetch_add) {
-        status.opcode = net_opcode_t::FETCH_ADD;
-        status.user_context = (void*)wcs[i].wr_id;
+      } else if (wcs[i].opcode == IBV_WC_FETCH_ADD) {
+        // LCI always records a posted atomic before handing it to ibverbs.
+        // Preserve the raw-operation distinction if the tracker was already
+        // torn down instead of treating its wr_id as user-owned storage.
+        status.opcode = net_opcode_t::ERROR;
+        status.rank = entry.rank;
+        status.user_context = nullptr;
+        status.failed_opcode = net_opcode_t::FETCH_ADD;
       } else {
         LCI_Assert(wcs[i].opcode == IBV_WC_RDMA_READ,
                    "Unexpected IBV opcode!\n");
@@ -287,7 +314,8 @@ inline void ibv_endpoint_impl_t::release_slot(int rank)
 }
 
 inline error_t ibv_endpoint_impl_t::prepare_atomic_operation(
-    int rank, bool uses_discard, size_t* discard_slot)
+    int rank, bool uses_discard, void* user_context, size_t* discard_slot,
+    uintptr_t* wr_id)
 {
   ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
   if (!tracker.lock.try_lock()) {
@@ -302,7 +330,8 @@ inline error_t ibv_endpoint_impl_t::prepare_atomic_operation(
     slot = tracker.free_discard_slots.back();
     tracker.free_discard_slots.pop_back();
   }
-  tracker.posted_ops.push_back({uses_discard, slot});
+  tracker.posted_ops.push_back({uses_discard, slot, user_context});
+  *wr_id = reinterpret_cast<uintptr_t>(&tracker.posted_ops.back());
   tracker.lock.unlock();
   if (discard_slot) {
     *discard_slot = slot;
@@ -310,34 +339,84 @@ inline error_t ibv_endpoint_impl_t::prepare_atomic_operation(
   return errorcode_t::done;
 }
 
-inline void ibv_endpoint_impl_t::cancel_atomic_operation(int rank)
+inline void ibv_endpoint_impl_t::cancel_atomic_operation(int rank,
+                                                         uintptr_t wr_id)
 {
   ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
   tracker.lock.lock();
-  LCI_DBG_Assert(!tracker.posted_ops.empty(),
-                 "No atomic operation to cancel for rank %d\n", rank);
-  ibv_atomic_op_t op = tracker.posted_ops.back();
-  tracker.posted_ops.pop_back();
-  if (op.uses_discard) {
-    tracker.free_discard_slots.push_back(op.discard_slot);
+  auto it = std::find_if(tracker.posted_ops.begin(), tracker.posted_ops.end(),
+                         [wr_id](const ibv_atomic_op_t& op) {
+                           return reinterpret_cast<uintptr_t>(&op) == wr_id;
+                         });
+  if (it == tracker.posted_ops.end()) {
+    tracker.lock.unlock();
+    LCI_Warn("No atomic operation to cancel for rank %d\n", rank);
+    return;
   }
+  if (it->uses_discard) {
+    tracker.free_discard_slots.push_back(it->discard_slot);
+  }
+  tracker.posted_ops.erase(it);
   tracker.lock.unlock();
 }
 
-inline void ibv_endpoint_impl_t::complete_atomic_operation(int rank)
+inline bool ibv_endpoint_impl_t::complete_atomic_operation(int rank,
+                                                           uintptr_t wr_id,
+                                                           void** user_context)
 {
+  if (atomic_trackers.empty()) {
+    return false;
+  }
   ibv_atomic_tracker_t& tracker = *atomic_trackers[rank];
   tracker.lock.lock();
-  LCI_Assert(!tracker.posted_ops.empty(),
-             "No atomic operation to complete for rank %d\n", rank);
-  ibv_atomic_op_t op = tracker.posted_ops.front();
-  tracker.posted_ops.pop_front();
-  if (op.uses_discard) {
-    tracker.free_discard_slots.push_back(op.discard_slot);
+  auto it = std::find_if(tracker.posted_ops.begin(), tracker.posted_ops.end(),
+                         [wr_id](const ibv_atomic_op_t& op) {
+                           return reinterpret_cast<uintptr_t>(&op) == wr_id;
+                         });
+  if (it == tracker.posted_ops.end()) {
+    tracker.lock.unlock();
+    return false;
   }
+  if (user_context) {
+    *user_context = it->user_context;
+  }
+  if (it->uses_discard) {
+    tracker.free_discard_slots.push_back(it->discard_slot);
+  }
+  tracker.posted_ops.erase(it);
   tracker.lock.unlock();
   sub_backend_pending_ops();
   LCI_PCOUNTER_ADD(net_atomic_comp, 1);
+  return true;
+}
+
+inline size_t ibv_atomic_tracker_t::abort()
+{
+  lock.lock();
+  const size_t aborted = posted_ops.size();
+  for (const ibv_atomic_op_t& op : posted_ops) {
+    if (op.uses_discard) {
+      free_discard_slots.push_back(op.discard_slot);
+    }
+  }
+  posted_ops.clear();
+  lock.unlock();
+  return aborted;
+}
+
+inline void ibv_endpoint_impl_t::abort_atomic_operations()
+{
+  size_t aborted = 0;
+  for (auto& tracker : atomic_trackers) {
+    aborted += tracker->abort();
+  }
+  if (aborted != 0) {
+    sub_backend_pending_ops(static_cast<int64_t>(aborted));
+    LCI_Log(LOG_INFO, "ibv",
+            "Aborted %lu outstanding uint64 atomic operations during "
+            "failed-device teardown\n",
+            aborted);
+  }
 }
 
 inline bool ibv_endpoint_impl_t::try_lock_qp(int rank)
@@ -733,7 +812,6 @@ inline error_t ibv_endpoint_impl_t::post_fetch_add_impl(
   list.lkey = ibv_detail::get_mr_lkey(result_mr);
 
   struct ibv_send_wr wr = {};
-  wr.wr_id = reinterpret_cast<uintptr_t>(user_context);
   wr.sg_list = &list;
   wr.num_sge = 1;
   wr.opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
@@ -749,23 +827,26 @@ inline error_t ibv_endpoint_impl_t::post_fetch_add_impl(
     release_slot(rank);
     return errorcode_t::retry_lock;
   }
-  error_t tracking_error = prepare_atomic_operation(rank, false, nullptr);
+  uintptr_t atomic_wr_id = 0;
+  error_t tracking_error = prepare_atomic_operation(rank, false, user_context,
+                                                    nullptr, &atomic_wr_id);
   if (tracking_error.is_retry()) {
     unlock_qp(rank);
     release_slot(rank);
     return tracking_error;
   }
+  wr.wr_id = atomic_wr_id;
   struct ibv_send_wr* bad_wr;
   int ret = ibv_post_send(ib_qps[rank], &wr, &bad_wr);
   unlock_qp(rank);
   if (ret == 0) {
     return errorcode_t::posted;
   } else if (ret == ENOMEM) {
-    cancel_atomic_operation(rank);
+    cancel_atomic_operation(rank, atomic_wr_id);
     release_slot(rank);
     return errorcode_t::retry_nomem;
   } else {
-    cancel_atomic_operation(rank);
+    cancel_atomic_operation(rank, atomic_wr_id);
     release_slot(rank);
     IBV_SAFECALL_RET(ret);
   }
@@ -787,7 +868,9 @@ inline error_t ibv_endpoint_impl_t::post_add_impl(int rank, uint64_t value,
     return errorcode_t::retry_lock;
   }
   size_t discard_slot = 0;
-  error_t tracking_error = prepare_atomic_operation(rank, true, &discard_slot);
+  uintptr_t atomic_wr_id = 0;
+  error_t tracking_error = prepare_atomic_operation(
+      rank, true, user_context, &discard_slot, &atomic_wr_id);
   if (tracking_error.is_retry()) {
     unlock_qp(rank);
     release_slot(rank);
@@ -801,7 +884,7 @@ inline error_t ibv_endpoint_impl_t::post_add_impl(int rank, uint64_t value,
   list.lkey = ibv_detail::get_mr_lkey(atomic_discard_mr);
 
   struct ibv_send_wr wr = {};
-  wr.wr_id = reinterpret_cast<uintptr_t>(user_context);
+  wr.wr_id = atomic_wr_id;
   wr.sg_list = &list;
   wr.num_sge = 1;
   wr.opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
@@ -816,11 +899,11 @@ inline error_t ibv_endpoint_impl_t::post_add_impl(int rank, uint64_t value,
   if (ret == 0) {
     return errorcode_t::posted;
   } else if (ret == ENOMEM) {
-    cancel_atomic_operation(rank);
+    cancel_atomic_operation(rank, atomic_wr_id);
     release_slot(rank);
     return errorcode_t::retry_nomem;
   } else {
-    cancel_atomic_operation(rank);
+    cancel_atomic_operation(rank, atomic_wr_id);
     release_slot(rank);
     IBV_SAFECALL_RET(ret);
   }

--- a/src/network/ibv/backend_ibv_inline.hpp
+++ b/src/network/ibv/backend_ibv_inline.hpp
@@ -157,13 +157,16 @@ inline size_t ibv_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
       net_status_t& status = p_statuses[i];
       memset(&status, 0, sizeof(status));
       if (wcs[i].status != IBV_WC_SUCCESS) {
-        status.opcode = net_opcode_t::ERROR;
+        const bool is_atomic_failure =
+            is_atomic || wcs[i].opcode == IBV_WC_FETCH_ADD;
+        status.opcode = is_atomic_failure ? net_opcode_t::FETCH_ADD_ERROR
+                                          : net_opcode_t::ERROR;
         status.rank = is_receive ? -1 : entry.rank;
-        if (is_atomic || wcs[i].opcode == IBV_WC_FETCH_ADD) {
-          // Raw atomic contexts are not internal_context_t instances. Never
-          // expose one through a generic error completion, which progress()
-          // is allowed to inspect as an LCI-owned context.
-          status.user_context = nullptr;
+        if (is_atomic_failure) {
+          // Raw atomic contexts are caller-owned. FETCH_ADD_ERROR keeps them
+          // available to net_poll_cq() callers without exposing them through
+          // the generic error path used by high-level progress.
+          status.user_context = atomic_user_context;
         } else {
           status.user_context = is_receive ? nullptr : (void*)wcs[i].wr_id;
         }

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -62,6 +62,18 @@ endpoint_impl_t::endpoint_impl_t(device_t device_, attr_t attr_)
   endpoint.p_impl = this;
 }
 
+endpoint_impl_t::~endpoint_impl_t()
+{
+  if (device.get_impl()->has_network_failed()) {
+    const size_t aborted = backlog_queue.abort();
+    if (aborted != 0) {
+      LCI_Log(LOG_INFO, "network",
+              "Aborted %lu queued operations during failed-device teardown\n",
+              aborted);
+    }
+  }
+}
+
 /*************************************************************************************
  * Interface implementations
  * **********************************************************************************/

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -55,7 +55,8 @@ endpoint_impl_t::endpoint_impl_t(device_t device_, attr_t attr_)
       attr(attr_),
       net_context_attr(device.get_impl()->net_context_attr),
       device_attr(device.get_attr()),
-      pending_ops(0)
+      pending_ops(0),
+      backend_pending_ops(0)
 {
   attr.uid = g_nendpoints++;
   endpoint.p_impl = this;

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -151,6 +151,14 @@ class endpoint_impl_t
   virtual error_t post_get_impl(int rank, void* buffer, size_t size, mr_t mr,
                                 uint64_t offset, rmr_t rmr, void* user_context,
                                 bool high_priority) = 0;
+  virtual error_t post_fetch_add_impl(int rank, uint64_t* result,
+                                      mr_t result_mr, uint64_t value,
+                                      uint64_t offset, rmr_t rmr,
+                                      void* user_context,
+                                      bool high_priority) = 0;
+  virtual error_t post_add_impl(int rank, uint64_t value, uint64_t offset,
+                                rmr_t rmr, void* user_context,
+                                bool high_priority) = 0;
 
   // wrapper functions
   inline error_t post_sends(int rank, void* buffer, size_t size,
@@ -176,6 +184,13 @@ class endpoint_impl_t
   inline error_t post_get(int rank, void* buffer, size_t size, mr_t mr,
                           uint64_t offset, rmr_t rmr, void* user_context,
                           bool allow_retry = true, bool force_post = false);
+  inline error_t post_fetch_add(int rank, uint64_t* result, mr_t result_mr,
+                                uint64_t value, uint64_t offset, rmr_t rmr,
+                                void* user_context, bool allow_retry = true,
+                                bool force_post = false);
+  inline error_t post_add(int rank, uint64_t value, uint64_t offset, rmr_t rmr,
+                          void* user_context, bool allow_retry = true,
+                          bool force_post = false);
   inline error_t post_putImms_fallback(int rank, void* buffer, size_t size,
                                        uint64_t offset, rmr_t rmr,
                                        net_imm_data_t imm_data,
@@ -209,9 +224,28 @@ class endpoint_impl_t
                    ret - n);
     // fprintf(stderr, "sub pending ops %ld - %ld = %ld\n", ret, n, ret - n);
   }
+  inline void add_backend_pending_ops(int64_t n = 1)
+  {
+    [[maybe_unused]] int64_t ret =
+        backend_pending_ops.fetch_add(n, std::memory_order_relaxed);
+    // fprintf(stderr, "add backend pending ops %ld + %ld = %ld\n", ret, n,
+    //         ret + n);
+  }
+  inline void sub_backend_pending_ops(int64_t n = 1)
+  {
+    [[maybe_unused]] int64_t ret =
+        backend_pending_ops.fetch_sub(n, std::memory_order_relaxed);
+    LCI_DBG_Assert(ret - n >= 0,
+                   "backend_pending_ops is negative! (n: %ld, "
+                   "backend_pending_ops: %ld)\n",
+                   n, ret - n);
+    // fprintf(stderr, "sub backend pending ops %ld - %ld = %ld\n", ret, n,
+    //         ret - n);
+  }
   inline int64_t get_pending_ops() const
   {
-    return pending_ops.load(std::memory_order_relaxed);
+    return pending_ops.load(std::memory_order_relaxed) +
+           backend_pending_ops.load(std::memory_order_relaxed);
   }
 
   runtime_t runtime;
@@ -227,6 +261,11 @@ class endpoint_impl_t
   backlog_queue_t backlog_queue;
   LCIU_CACHE_PADDING(sizeof(backlog_queue_t));
   std::atomic<int64_t> pending_ops;
+  LCIU_CACHE_PADDING(sizeof(std::atomic<int64_t>));
+  // Raw operations that own backend-managed storage do not have an
+  // internal_context_t to keep the endpoint alive. Track them separately so
+  // wait_drained() also waits for the backend to retire that storage.
+  std::atomic<int64_t> backend_pending_ops;
   LCIU_CACHE_PADDING(sizeof(std::atomic<int64_t>));
 };
 

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -127,7 +127,7 @@ class endpoint_impl_t
 
   // functions for backends to implement
   endpoint_impl_t(device_t device_, attr_t attr_);
-  virtual ~endpoint_impl_t() = default;
+  virtual ~endpoint_impl_t();
   virtual error_t post_sends_impl(int rank, void* buffer, size_t size,
                                   net_imm_data_t imm_data, void* user_context,
                                   bool high_priority) = 0;

--- a/src/network/network.hpp
+++ b/src/network/network.hpp
@@ -186,9 +186,11 @@ class endpoint_impl_t
                           bool allow_retry = true, bool force_post = false);
   inline error_t post_fetch_add(int rank, uint64_t* result, mr_t result_mr,
                                 uint64_t value, uint64_t offset, rmr_t rmr,
+                                net_atomic_scope_t required_atomic_scope,
                                 void* user_context, bool allow_retry = true,
                                 bool force_post = false);
   inline error_t post_add(int rank, uint64_t value, uint64_t offset, rmr_t rmr,
+                          net_atomic_scope_t required_atomic_scope,
                           void* user_context, bool allow_retry = true,
                           bool force_post = false);
   inline error_t post_putImms_fallback(int rank, void* buffer, size_t size,

--- a/src/network/network_inline.hpp
+++ b/src/network/network_inline.hpp
@@ -170,6 +170,37 @@ inline error_t net_post_get_x::call_impl(int rank, void* buffer, size_t size,
   return ret;
 }
 
+inline error_t net_post_fetch_add_x::call_impl(int rank, uint64_t* result,
+                                               mr_t result_mr, uint64_t value,
+                                               uint64_t offset, rmr_t rmr,
+                                               runtime_t, device_t,
+                                               endpoint_t endpoint,
+                                               void* user_context) const
+{
+  auto ret = endpoint.p_impl->post_fetch_add(rank, result, result_mr, value,
+                                             offset, rmr, user_context);
+  LCI_DBG_Log(LOG_TRACE, "network",
+              "post_fetch_add rank %d result %p result_mr %p value %lu "
+              "offset %lu rmr %p user_context %p return %s\n",
+              rank, result, result_mr.p_impl, value, offset,
+              reinterpret_cast<void*>(rmr.base), user_context, ret.get_str());
+  return ret;
+}
+
+inline error_t net_post_add_x::call_impl(int rank, uint64_t value,
+                                         uint64_t offset, rmr_t rmr, runtime_t,
+                                         device_t, endpoint_t endpoint,
+                                         void* user_context) const
+{
+  auto ret = endpoint.p_impl->post_add(rank, value, offset, rmr, user_context);
+  LCI_DBG_Log(LOG_TRACE, "network",
+              "post_add rank %d value %lu offset %lu rmr %p user_context %p "
+              "return %s\n",
+              rank, value, offset, reinterpret_cast<void*>(rmr.base),
+              user_context, ret.get_str());
+  return ret;
+}
+
 }  // namespace lci
 
 #endif  // LCI_BACKEND_INLINE_HPP

--- a/src/network/network_inline.hpp
+++ b/src/network/network_inline.hpp
@@ -170,34 +170,38 @@ inline error_t net_post_get_x::call_impl(int rank, void* buffer, size_t size,
   return ret;
 }
 
-inline error_t net_post_fetch_add_x::call_impl(int rank, uint64_t* result,
-                                               mr_t result_mr, uint64_t value,
-                                               uint64_t offset, rmr_t rmr,
-                                               runtime_t, device_t,
-                                               endpoint_t endpoint,
-                                               void* user_context) const
+inline error_t net_post_fetch_add_x::call_impl(
+    int rank, uint64_t* result, mr_t result_mr, uint64_t value, uint64_t offset,
+    rmr_t rmr, runtime_t, net_atomic_scope_t required_atomic_scope, device_t,
+    endpoint_t endpoint, void* user_context) const
 {
-  auto ret = endpoint.p_impl->post_fetch_add(rank, result, result_mr, value,
-                                             offset, rmr, user_context);
+  auto ret =
+      endpoint.p_impl->post_fetch_add(rank, result, result_mr, value, offset,
+                                      rmr, required_atomic_scope, user_context);
   LCI_DBG_Log(LOG_TRACE, "network",
               "post_fetch_add rank %d result %p result_mr %p value %lu "
-              "offset %lu rmr %p user_context %p return %s\n",
+              "offset %lu rmr %p required_atomic_scope %d user_context %p "
+              "return %s\n",
               rank, result, result_mr.p_impl, value, offset,
-              reinterpret_cast<void*>(rmr.base), user_context, ret.get_str());
+              reinterpret_cast<void*>(rmr.base),
+              static_cast<int>(required_atomic_scope), user_context,
+              ret.get_str());
   return ret;
 }
 
-inline error_t net_post_add_x::call_impl(int rank, uint64_t value,
-                                         uint64_t offset, rmr_t rmr, runtime_t,
-                                         device_t, endpoint_t endpoint,
-                                         void* user_context) const
+inline error_t net_post_add_x::call_impl(
+    int rank, uint64_t value, uint64_t offset, rmr_t rmr, runtime_t,
+    net_atomic_scope_t required_atomic_scope, device_t, endpoint_t endpoint,
+    void* user_context) const
 {
-  auto ret = endpoint.p_impl->post_add(rank, value, offset, rmr, user_context);
+  auto ret = endpoint.p_impl->post_add(rank, value, offset, rmr,
+                                       required_atomic_scope, user_context);
   LCI_DBG_Log(LOG_TRACE, "network",
-              "post_add rank %d value %lu offset %lu rmr %p user_context %p "
-              "return %s\n",
+              "post_add rank %d value %lu offset %lu rmr %p "
+              "required_atomic_scope %d user_context %p return %s\n",
               rank, value, offset, reinterpret_cast<void*>(rmr.base),
-              user_context, ret.get_str());
+              static_cast<int>(required_atomic_scope), user_context,
+              ret.get_str());
   return ret;
 }
 

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -186,6 +186,10 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   }
   // Check put with immediate support.
   attr.support_putimm = true;
+  // Do not emulate fetch-add through non-atomic RMA. The public capability
+  // explicitly reports that this backend does not provide the required
+  // uint64 atomic semantics.
+  attr.support_uint64_fetch_add = false;
   std::string prov_name = ofi_info->fabric_attr->prov_name;
   if (prov_name == "cxi") {
     // CXI writedata uses provider keys and the domain's CQ-data support.

--- a/src/network/ofi/backend_ofi.cpp
+++ b/src/network/ofi/backend_ofi.cpp
@@ -189,7 +189,7 @@ ofi_net_context_impl_t::ofi_net_context_impl_t(runtime_t runtime_, attr_t attr_)
   // Do not emulate fetch-add through non-atomic RMA. The public capability
   // explicitly reports that this backend does not provide the required
   // uint64 atomic semantics.
-  attr.support_uint64_fetch_add = false;
+  attr.atomic_scope = net_atomic_scope_t::NONE;
   std::string prov_name = ofi_info->fabric_attr->prov_name;
   if (prov_name == "cxi") {
     // CXI writedata uses provider keys and the domain's CQ-data support.

--- a/src/network/ofi/backend_ofi.hpp
+++ b/src/network/ofi/backend_ofi.hpp
@@ -146,6 +146,11 @@ class ofi_endpoint_impl_t : public lci::endpoint_impl_t
   error_t post_get_impl(int rank, void* buffer, size_t size, mr_t mr,
                         uint64_t offset, rmr_t rmr, void* user_context,
                         bool high_priority) override;
+  error_t post_fetch_add_impl(int rank, uint64_t* result, mr_t result_mr,
+                              uint64_t value, uint64_t offset, rmr_t rmr,
+                              void* user_context, bool high_priority) override;
+  error_t post_add_impl(int rank, uint64_t value, uint64_t offset, rmr_t rmr,
+                        void* user_context, bool high_priority) override;
 
   ofi_device_impl_t* p_ofi_device;
   int my_rank;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -76,7 +76,6 @@ inline size_t ofi_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
         memset(&status, 0, sizeof(status));
         status.opcode = net_opcode_t::ERROR;
         status.rank = -1;
-        status.failed_opcode = net_opcode_t::ERROR;
         const bool is_outgoing =
             (error.flags & (FI_SEND | FI_WRITE | FI_READ)) != 0 &&
             (error.flags & (FI_RECV | FI_REMOTE_WRITE)) == 0;

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -437,6 +437,21 @@ inline error_t ofi_endpoint_impl_t::post_get_impl(int rank, void* buffer,
     FI_SAFECALL_RET(ret);
   }
 }
+
+inline error_t ofi_endpoint_impl_t::post_fetch_add_impl(int, uint64_t*, mr_t,
+                                                        uint64_t, uint64_t,
+                                                        rmr_t, void*, bool)
+{
+  LCI_Warn("uint64 network fetch-add is not implemented for the OFI backend\n");
+  return errorcode_t::fatal;
+}
+
+inline error_t ofi_endpoint_impl_t::post_add_impl(int, uint64_t, uint64_t,
+                                                  rmr_t, void*, bool)
+{
+  LCI_Warn("uint64 network add is not implemented for the OFI backend\n");
+  return errorcode_t::fatal;
+}
 }  // namespace lci
 
 #endif  // LCI_BACKEND_OFI_BACKEND_OFI_INLINE_HPP

--- a/src/network/ofi/backend_ofi_inline.hpp
+++ b/src/network/ofi/backend_ofi_inline.hpp
@@ -70,11 +70,13 @@ inline size_t ofi_device_impl_t::poll_comp_impl(net_status_t* p_statuses,
     } else {
       LCI_Assert(ret_cqerr == 1, "fi_cq_readerr failed: %s\n",
                  fi_strerror(-ret_cqerr));
+      mark_network_failed();
       if (p_statuses) {
         net_status_t& status = p_statuses[0];
         memset(&status, 0, sizeof(status));
         status.opcode = net_opcode_t::ERROR;
         status.rank = -1;
+        status.failed_opcode = net_opcode_t::ERROR;
         const bool is_outgoing =
             (error.flags & (FI_SEND | FI_WRITE | FI_READ)) != 0 &&
             (error.flags & (FI_RECV | FI_REMOTE_WRITE)) == 0;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -36,6 +36,7 @@ if(CMAKE_VERSION VERSION_LESS 2.8.11)
 endif()
 
 add_subdirectory(loopback)
+add_subdirectory(atomic)
 add_subdirectory(collective)
 add_subdirectory(cxx11)
 add_subdirectory(accelerator)

--- a/tests/unit/atomic/CMakeLists.txt
+++ b/tests/unit/atomic/CMakeLists.txt
@@ -3,6 +3,12 @@
 
 get_target_property(LCI_LINKED_LIBS LCI LINK_LIBRARIES)
 
+set(LCI_ATOMIC_TEST_DEPENDENCIES ${LCI_LINKED_LIBS})
+if(LCI_USE_HIP)
+  set_source_files_properties(test_network_atomic.cpp PROPERTIES LANGUAGE HIP)
+  list(APPEND LCI_ATOMIC_TEST_DEPENDENCIES hip::host)
+endif()
+
 if(LCI_BACKEND_ENABLE_OFI)
   add_lci_test(
     test-atomic-network-unsupported
@@ -16,10 +22,20 @@ if(LCI_BACKEND_ENABLE_OFI)
     INCLUDES
     ${PROJECT_SOURCE_DIR}/src
     DEPENDENCIES
-    ${LCI_LINKED_LIBS})
+    ${LCI_ATOMIC_TEST_DEPENDENCIES})
 endif()
 
 if(LCI_BACKEND_ENABLE_IBV)
+  set(LCI_ATOMIC_IBV_COMMANDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/run_ibv_atomic_test.sh ${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] --require-ibv"
+  )
+  if(LCI_USE_HIP)
+    list(
+      APPEND
+      LCI_ATOMIC_IBV_COMMANDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/run_ibv_atomic_test.sh ${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] --require-ibv-gpu"
+    )
+  endif()
   add_lci_test(
     test-atomic-network-ibv
     SOURCES
@@ -29,10 +45,25 @@ if(LCI_BACKEND_ENABLE_IBV)
     ibv
     hardware
     COMMANDS
-    "${CMAKE_CURRENT_SOURCE_DIR}/run_ibv_atomic_test.sh ${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] --require-ibv"
+    ${LCI_ATOMIC_IBV_COMMANDS}
     INCLUDES
     ${PROJECT_SOURCE_DIR}/src
     DEPENDENCIES
-    ${LCI_LINKED_LIBS})
+    ${LCI_ATOMIC_TEST_DEPENDENCIES})
   set_tests_properties(test-atomic-network-ibv PROPERTIES SKIP_RETURN_CODE 77)
+  if(LCI_USE_HIP)
+    set_tests_properties(test-atomic-network-ibv-1 PROPERTIES SKIP_RETURN_CODE
+                                                              77)
+  endif()
+endif()
+
+if(LCI_USE_HIP)
+  foreach(target test-atomic-network-unsupported test-atomic-network-ibv)
+    if(TARGET ${target})
+      set_target_hip_standard(${target} STANDARD ${LCI_HIP_STANDARD})
+      set_target_hip_architectures(${target} ARCHITECTURES ${LCI_HIP_ARCH})
+      set_target_hip_warnings_and_errors(${target} WARN_AS_ERROR
+                                         ${LCI_BUILD_WARN_AS_ERROR})
+    endif()
+  endforeach()
 endif()

--- a/tests/unit/atomic/CMakeLists.txt
+++ b/tests/unit/atomic/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 The LCI Project Authors
+# SPDX-License-Identifier: NCSA
+
+get_target_property(LCI_LINKED_LIBS LCI LINK_LIBRARIES)
+
+if(LCI_BACKEND_ENABLE_OFI)
+  add_lci_test(
+    test-atomic-network-unsupported
+    SOURCES
+    test_network_atomic.cpp
+    LABELS
+    atomic
+    ofi
+    COMMANDS
+    "env LCI_ATTR_BACKEND=ofi [TARGET] --expect-unsupported"
+    INCLUDES
+    ${PROJECT_SOURCE_DIR}/src
+    DEPENDENCIES
+    ${LCI_LINKED_LIBS})
+endif()
+
+if(LCI_BACKEND_ENABLE_IBV)
+  add_lci_test(
+    test-atomic-network-ibv
+    SOURCES
+    test_network_atomic.cpp
+    LABELS
+    atomic
+    ibv
+    hardware
+    COMMANDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/run_ibv_atomic_test.sh ${LCI_USE_CTEST_LAUNCHER} -n 2 ${LCI_USE_CTEST_ARGS} [TARGET] --require-ibv"
+    INCLUDES
+    ${PROJECT_SOURCE_DIR}/src
+    DEPENDENCIES
+    ${LCI_LINKED_LIBS})
+  set_tests_properties(test-atomic-network-ibv PROPERTIES SKIP_RETURN_CODE 77)
+endif()

--- a/tests/unit/atomic/run_ibv_atomic_test.sh
+++ b/tests/unit/atomic/run_ibv_atomic_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The LCI Project Authors
+# SPDX-License-Identifier: NCSA
+
+set -euo pipefail
+
+if [[ "$#" -eq 0 ]]; then
+  echo "Usage: $0 <launcher> [launcher arguments] <test> --require-ibv" >&2
+  exit 2
+fi
+
+has_active_port=0
+for state_file in /sys/class/infiniband/*/ports/*/state; do
+  [[ -r "${state_file}" ]] || continue
+  if grep -q "ACTIVE" "${state_file}"; then
+    has_active_port=1
+    break
+  fi
+done
+
+if [[ "${has_active_port}" -eq 0 ]]; then
+  echo "SKIP: no active IBV port is available for the uint64 atomic test" >&2
+  exit 77
+fi
+
+export LCI_ATTR_BACKEND=ibv
+exec "$@"

--- a/tests/unit/atomic/run_ibv_atomic_test.sh
+++ b/tests/unit/atomic/run_ibv_atomic_test.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 if [[ "$#" -eq 0 ]]; then
-  echo "Usage: $0 <launcher> [launcher arguments] <test> --require-ibv" >&2
+  echo "Usage: $0 <launcher> [launcher arguments] <test> --require-ibv[|-gpu]" >&2
   exit 2
 fi
 

--- a/tests/unit/atomic/test_network_atomic.cpp
+++ b/tests/unit/atomic/test_network_atomic.cpp
@@ -1,0 +1,340 @@
+// Copyright (c) 2026 The LCI Project Authors
+// SPDX-License-Identifier: NCSA
+
+#include "lci.hpp"
+#include "lci_internal.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace
+{
+constexpr int kSkipReturnCode = 77;
+constexpr int kMaxPolls = 1000000;
+
+enum class test_mode_t {
+  expect_unsupported,
+  require_ibv,
+};
+
+[[noreturn]] void fail(const char* message)
+{
+  std::fprintf(stderr, "network atomic test failure: %s\n", message);
+  std::abort();
+}
+
+void check(bool condition, const char* message)
+{
+  if (!condition) {
+    fail(message);
+  }
+}
+
+void bootstrap_barrier() { LCT_pmi_barrier(); }
+
+struct alignas(uint64_t) remote_words_t {
+  uint64_t ordered_value;
+  uint64_t counter;
+};
+
+struct completion_context_t {
+  lci::net_opcode_t opcode;
+  bool seen = false;
+};
+
+void wait_for_completions(lci::runtime_t runtime, lci::device_t device,
+                          const std::vector<completion_context_t*>& expected)
+{
+  size_t completed = 0;
+  for (int attempt = 0; attempt < kMaxPolls && completed < expected.size();
+       ++attempt) {
+    lci::net_status_t status = {};
+    const size_t n =
+        lci::net_poll_cq_x(1, &status).runtime(runtime).device(device)();
+    if (n == 0) {
+      continue;
+    }
+    check(n == 1, "net_poll_cq returned an unexpected completion count");
+    check(status.opcode != lci::net_opcode_t::ERROR,
+          "network atomic operation completed with an error");
+    auto* context = static_cast<completion_context_t*>(status.user_context);
+    bool matched = false;
+    for (completion_context_t* candidate : expected) {
+      if (candidate == context) {
+        check(!candidate->seen, "network atomic completion was duplicated");
+        check(status.opcode == candidate->opcode,
+              "network atomic completion reported the wrong opcode");
+        candidate->seen = true;
+        ++completed;
+        matched = true;
+        break;
+      }
+    }
+    check(matched, "network atomic completion had an unexpected context");
+  }
+  check(completed == expected.size(), "network atomic completion timed out");
+}
+
+void free_runtime_objects(lci::runtime_t runtime, lci::device_t* device,
+                          lci::endpoint_t* endpoint)
+{
+  if (!endpoint->is_empty()) {
+    lci::free_endpoint_x(endpoint).runtime(runtime)();
+  }
+  if (!device->is_empty()) {
+    lci::free_device_x(device).runtime(runtime)();
+  }
+  lci::g_runtime_fina();
+}
+
+int run_test(test_mode_t mode)
+{
+  lci::runtime_t runtime = lci::g_runtime_init_x()
+                               .alloc_default_device(false)
+                               .alloc_default_packet_pool(false)
+                               .alloc_default_matching_engine(false)();
+  // This raw-RMA test deliberately avoids a packet pool. Keep QP/RMR
+  // bootstrap on PMI so bootstrap::alltoall does not invoke LCI collectives
+  // that require a bound packet pool.
+  lci::internal_config::enable_bootstrap_lci = false;
+  lci::net_context_t net_context =
+      lci::get_default_net_context_x().runtime(runtime)();
+  lci::device_t device = lci::alloc_device_x()
+                             .runtime(runtime)
+                             .net_max_sends(4)
+                             .alloc_default_endpoint(false)
+                             .alloc_progress_endpoint(false)
+                             .shm_enable(false)();
+  lci::endpoint_t endpoint =
+      lci::alloc_endpoint_x().runtime(runtime).device(device)();
+
+  const bool supports_fetch_add =
+      net_context.get_attr_support_uint64_fetch_add();
+  if (mode == test_mode_t::expect_unsupported) {
+    check(!supports_fetch_add,
+          "OFI unexpectedly advertised uint64 fetch-add support");
+    uint64_t result = 0;
+    lci::error_t fetch_error =
+        lci::net_post_fetch_add_x(0, &result, lci::MR_HOST, 1, 0, lci::RMR_NULL)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)();
+    lci::error_t add_error = lci::net_post_add_x(0, 1, 0, lci::RMR_NULL)
+                                 .runtime(runtime)
+                                 .device(device)
+                                 .endpoint(endpoint)();
+    check(fetch_error.errorcode == lci::errorcode_t::fatal,
+          "unsupported fetch-add did not fail explicitly");
+    check(add_error.errorcode == lci::errorcode_t::fatal,
+          "unsupported add did not fail explicitly");
+    free_runtime_objects(runtime, &device, &endpoint);
+    return 0;
+  }
+
+  if (net_context.get_attr_backend() != lci::attr_backend_t::ibv ||
+      !supports_fetch_add) {
+    free_runtime_objects(runtime, &device, &endpoint);
+    return kSkipReturnCode;
+  }
+
+  check(lci::get_rank_n() == 2,
+        "the IBV network atomic test requires exactly two ranks");
+  const int rank = lci::get_rank_me();
+  const int peer = 1 - rank;
+
+  remote_words_t target = {};
+  target.counter = 100;
+  alignas(uint64_t) uint64_t fetch_result = 0;
+  alignas(uint64_t) uint64_t ordered_value = 0x123456789abcdef0ULL;
+  std::array<unsigned char, 16> misaligned_result_storage = {};
+
+  lci::mr_t target_mr = lci::register_memory_x(&target, sizeof(target))
+                            .runtime(runtime)
+                            .device(device)();
+  lci::mr_t result_mr =
+      lci::register_memory_x(&fetch_result, sizeof(fetch_result))
+          .runtime(runtime)
+          .device(device)();
+  lci::mr_t ordered_value_mr =
+      lci::register_memory_x(&ordered_value, sizeof(ordered_value))
+          .runtime(runtime)
+          .device(device)();
+  lci::mr_t misaligned_result_mr =
+      lci::register_memory_x(misaligned_result_storage.data(),
+                             misaligned_result_storage.size())
+          .runtime(runtime)
+          .device(device)();
+
+  lci::rmr_t local_rmr = lci::get_rmr(target_mr);
+  std::array<lci::rmr_t, 2> local_rmrs = {local_rmr, local_rmr};
+  std::array<lci::rmr_t, 2> remote_rmrs = {};
+  lci::bootstrap::alltoall(local_rmrs.data(), remote_rmrs.data(),
+                           sizeof(local_rmr));
+  const lci::rmr_t peer_rmr = remote_rmrs[peer];
+  constexpr uint64_t counter_offset = offsetof(remote_words_t, counter);
+  constexpr uint64_t ordered_value_offset =
+      offsetof(remote_words_t, ordered_value);
+
+  bootstrap_barrier();
+  if (rank == 0) {
+    uint64_t* misaligned_result =
+        reinterpret_cast<uint64_t*>(misaligned_result_storage.data() + 1);
+    lci::error_t misaligned_result_error =
+        lci::net_post_fetch_add_x(peer, misaligned_result, misaligned_result_mr,
+                                  1, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)();
+    lci::error_t misaligned_remote_error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
+                                  counter_offset + 1, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)();
+    check(misaligned_result_error.errorcode == lci::errorcode_t::fatal,
+          "misaligned fetch-add result was accepted");
+    check(misaligned_remote_error.errorcode == lci::errorcode_t::fatal,
+          "misaligned fetch-add remote address was accepted");
+  }
+  bootstrap_barrier();
+
+  if (rank == 0) {
+    completion_context_t fetch_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 7,
+                                  counter_offset, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&fetch_context)();
+    check(error.is_posted(), "fetch-add was not posted");
+    wait_for_completions(runtime, device, {&fetch_context});
+    check(fetch_result == 100, "fetch-add returned the wrong previous value");
+  }
+  bootstrap_barrier();
+  if (rank == 1) {
+    check(target.counter == 107, "fetch-add did not update the remote value");
+  }
+  bootstrap_barrier();
+
+  if (rank == 0) {
+    completion_context_t add_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t error = lci::net_post_add_x(peer, 3, counter_offset, peer_rmr)
+                             .runtime(runtime)
+                             .device(device)
+                             .endpoint(endpoint)
+                             .user_context(&add_context)();
+    check(error.is_posted(), "non-fetch add was not posted");
+    wait_for_completions(runtime, device, {&add_context});
+  }
+  bootstrap_barrier();
+  if (rank == 1) {
+    check(target.counter == 110,
+          "non-fetch add did not update the remote value");
+  }
+  bootstrap_barrier();
+
+  if (rank == 0) {
+    completion_context_t write_context{lci::net_opcode_t::WRITE};
+    completion_context_t ordered_fetch_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t put_error =
+        lci::net_post_put_x(peer, &ordered_value, sizeof(ordered_value),
+                            ordered_value_mr, ordered_value_offset, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&write_context)();
+    lci::error_t fetch_error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 5,
+                                  counter_offset, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&ordered_fetch_context)();
+    check(put_error.is_posted(), "ordering write was not posted");
+    check(fetch_error.is_posted(), "ordering fetch-add was not posted");
+    wait_for_completions(runtime, device,
+                         {&write_context, &ordered_fetch_context});
+    check(fetch_result == 110,
+          "ordering fetch-add returned the wrong previous value");
+  }
+  bootstrap_barrier();
+  if (rank == 1) {
+    check(target.ordered_value == ordered_value,
+          "same-QP write did not precede fetch-add at the remote rank");
+    check(target.counter == 115,
+          "ordering fetch-add did not update the remote value");
+  }
+  bootstrap_barrier();
+
+  if (rank == 0) {
+    std::array<completion_context_t, 5> add_contexts = {
+        completion_context_t{lci::net_opcode_t::FETCH_ADD},
+        completion_context_t{lci::net_opcode_t::FETCH_ADD},
+        completion_context_t{lci::net_opcode_t::FETCH_ADD},
+        completion_context_t{lci::net_opcode_t::FETCH_ADD},
+        completion_context_t{lci::net_opcode_t::FETCH_ADD},
+    };
+    std::vector<completion_context_t*> first_batch;
+    for (size_t i = 0; i < 4; ++i) {
+      lci::error_t error = endpoint.get_impl()->post_add(
+          peer, 1, counter_offset, peer_rmr, &add_contexts[i],
+          false /* allow_retry */);
+      check(error.is_posted(), "batched non-fetch add was not posted");
+      first_batch.push_back(&add_contexts[i]);
+    }
+    lci::error_t backlog_error = endpoint.get_impl()->post_add(
+        peer, 1, counter_offset, peer_rmr, &add_contexts.back(),
+        false /* allow_retry */);
+    check(backlog_error.errorcode == lci::errorcode_t::posted_backlog,
+          "non-fetch add did not enter the backlog when the QP was full");
+    check(!endpoint.get_impl()->is_backlog_queue_empty(peer),
+          "non-fetch add backlog entry was lost");
+    wait_for_completions(runtime, device, first_batch);
+    check(endpoint.get_impl()->get_pending_ops() == 0,
+          "completed non-fetch adds remained pending");
+    check(endpoint.get_impl()->progress_backlog_queue(),
+          "non-fetch add backlog entry did not progress");
+    check(endpoint.get_impl()->is_backlog_queue_empty(peer),
+          "non-fetch add backlog was not drained");
+    wait_for_completions(runtime, device, {&add_contexts.back()});
+    check(endpoint.get_impl()->get_pending_ops() == 0,
+          "backlogged non-fetch add remained pending");
+  }
+  bootstrap_barrier();
+  if (rank == 1) {
+    check(target.counter == 120,
+          "batched or backlogged non-fetch adds lost an update");
+  }
+  bootstrap_barrier();
+
+  lci::deregister_memory_x(&misaligned_result_mr).runtime(runtime)();
+  lci::deregister_memory_x(&ordered_value_mr).runtime(runtime)();
+  lci::deregister_memory_x(&result_mr).runtime(runtime)();
+  lci::deregister_memory_x(&target_mr).runtime(runtime)();
+  free_runtime_objects(runtime, &device, &endpoint);
+  return 0;
+}
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  if (argc != 2) {
+    std::fprintf(stderr, "Usage: %s --expect-unsupported|--require-ibv\n",
+                 argv[0]);
+    return 2;
+  }
+  if (std::strcmp(argv[1], "--expect-unsupported") == 0) {
+    return run_test(test_mode_t::expect_unsupported);
+  }
+  if (std::strcmp(argv[1], "--require-ibv") == 0) {
+    return run_test(test_mode_t::require_ibv);
+  }
+  std::fprintf(stderr, "Unknown mode '%s'\n", argv[1]);
+  return 2;
+}

--- a/tests/unit/atomic/test_network_atomic.cpp
+++ b/tests/unit/atomic/test_network_atomic.cpp
@@ -162,7 +162,8 @@ void wait_for_completions(lci::runtime_t runtime, lci::device_t device,
       continue;
     }
     check(n == 1, "net_poll_cq returned an unexpected completion count");
-    check(status.opcode != lci::net_opcode_t::ERROR,
+    check(status.opcode != lci::net_opcode_t::ERROR &&
+              status.opcode != lci::net_opcode_t::FETCH_ADD_ERROR,
           "network atomic operation completed with an error");
     auto* context = static_cast<completion_context_t*>(status.user_context);
     bool matched = false;

--- a/tests/unit/atomic/test_network_atomic.cpp
+++ b/tests/unit/atomic/test_network_atomic.cpp
@@ -53,6 +53,8 @@ struct completion_context_t {
 
 void wait_for_completions(lci::runtime_t runtime, lci::device_t device,
                           const std::vector<completion_context_t*>& expected);
+void wait_for_discarded_completion(lci::runtime_t runtime,
+                                   lci::device_t device);
 
 const char* atomic_scope_str(lci::net_atomic_scope_t scope)
 {
@@ -180,6 +182,19 @@ void wait_for_completions(lci::runtime_t runtime, lci::device_t device,
   check(completed == expected.size(), "network atomic completion timed out");
 }
 
+void wait_for_discarded_completion(lci::runtime_t runtime, lci::device_t device)
+{
+  for (int attempt = 0; attempt < kMaxPolls; ++attempt) {
+    const size_t n =
+        lci::net_poll_cq_x(1, nullptr).runtime(runtime).device(device)();
+    if (n == 1) {
+      return;
+    }
+    check(n == 0, "net_poll_cq returned an unexpected completion count");
+  }
+  fail("discarded network atomic completion timed out");
+}
+
 void free_runtime_objects(lci::runtime_t runtime, lci::device_t* device,
                           lci::endpoint_t* endpoint)
 {
@@ -219,22 +234,39 @@ int run_test(test_mode_t mode)
     check(atomic_scope == lci::net_atomic_scope_t::NONE,
           "OFI unexpectedly advertised uint64 fetch-add support");
     uint64_t result = 0;
-    lci::error_t fetch_error =
+    for (const lci::net_atomic_scope_t required_scope :
+         {lci::net_atomic_scope_t::NONE, lci::net_atomic_scope_t::HCA,
+          lci::net_atomic_scope_t::GLOBAL}) {
+      lci::error_t fetch_error =
+          lci::net_post_fetch_add_x(0, &result, lci::MR_HOST, 1, 0,
+                                    lci::RMR_NULL)
+              .runtime(runtime)
+              .required_atomic_scope(required_scope)
+              .device(device)
+              .endpoint(endpoint)();
+      lci::error_t add_error = lci::net_post_add_x(0, 1, 0, lci::RMR_NULL)
+                                   .runtime(runtime)
+                                   .required_atomic_scope(required_scope)
+                                   .device(device)
+                                   .endpoint(endpoint)();
+      check(fetch_error.errorcode == lci::errorcode_t::fatal,
+            "unsupported fetch-add scope was accepted");
+      check(add_error.errorcode == lci::errorcode_t::fatal,
+            "unsupported add scope was accepted");
+    }
+    lci::error_t default_fetch_error =
         lci::net_post_fetch_add_x(0, &result, lci::MR_HOST, 1, 0, lci::RMR_NULL)
             .runtime(runtime)
-            .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
             .device(device)
             .endpoint(endpoint)();
-    lci::error_t add_error =
-        lci::net_post_add_x(0, 1, 0, lci::RMR_NULL)
-            .runtime(runtime)
-            .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
-            .device(device)
-            .endpoint(endpoint)();
-    check(fetch_error.errorcode == lci::errorcode_t::fatal,
-          "unsupported fetch-add did not fail explicitly");
-    check(add_error.errorcode == lci::errorcode_t::fatal,
-          "unsupported add did not fail explicitly");
+    lci::error_t default_add_error = lci::net_post_add_x(0, 1, 0, lci::RMR_NULL)
+                                         .runtime(runtime)
+                                         .device(device)
+                                         .endpoint(endpoint)();
+    check(default_fetch_error.errorcode == lci::errorcode_t::fatal,
+          "unsupported default fetch-add scope was accepted");
+    check(default_add_error.errorcode == lci::errorcode_t::fatal,
+          "unsupported default add scope was accepted");
     free_runtime_objects(runtime, &device, &endpoint);
     return 0;
   }
@@ -323,13 +355,6 @@ int run_test(test_mode_t mode)
             .required_atomic_scope(atomic_scope)
             .device(device)
             .endpoint(endpoint)();
-    lci::error_t no_scope_error =
-        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
-                                  counter_offset, peer_rmr)
-            .runtime(runtime)
-            .required_atomic_scope(lci::net_atomic_scope_t::NONE)
-            .device(device)
-            .endpoint(endpoint)();
     check(empty_rmr_fetch_error.errorcode == lci::errorcode_t::fatal,
           "empty RMR fetch-add was accepted");
     check(empty_rmr_add_error.errorcode == lci::errorcode_t::fatal,
@@ -338,19 +363,90 @@ int run_test(test_mode_t mode)
           "misaligned fetch-add result was accepted");
     check(misaligned_remote_error.errorcode == lci::errorcode_t::fatal,
           "misaligned fetch-add remote address was accepted");
-    check(no_scope_error.errorcode == lci::errorcode_t::fatal,
-          "fetch-add accepted a NONE required atomic scope");
-    if (atomic_scope == lci::net_atomic_scope_t::HCA) {
-      lci::error_t global_scope_error =
-          lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
-                                    counter_offset, peer_rmr)
-              .runtime(runtime)
-              .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
-              .device(device)
-              .endpoint(endpoint)();
-      check(global_scope_error.errorcode == lci::errorcode_t::fatal,
+  }
+  bootstrap_barrier();
+
+  if (rank == 0) {
+    completion_context_t hca_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t hca_error =
+        lci::net_post_add_x(peer, 0, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::HCA)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&hca_context)();
+    check(hca_error.is_posted(), "HCA atomic scope was not accepted");
+    wait_for_completions(runtime, device, {&hca_context});
+
+    completion_context_t global_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t global_error =
+        lci::net_post_add_x(peer, 0, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&global_context)();
+    if (atomic_scope == lci::net_atomic_scope_t::GLOBAL) {
+      check(global_error.is_posted(),
+            "GLOBAL atomic scope was not accepted by a GLOBAL backend");
+      wait_for_completions(runtime, device, {&global_context});
+    } else {
+      check(global_error.errorcode == lci::errorcode_t::fatal,
             "HCA atomic capability was accepted as GLOBAL");
     }
+
+    completion_context_t default_add_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t default_add_error =
+        lci::net_post_add_x(peer, 0, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&default_add_context)();
+    if (atomic_scope == lci::net_atomic_scope_t::GLOBAL) {
+      check(default_add_error.is_posted(),
+            "default add scope was not accepted by a GLOBAL backend");
+      wait_for_completions(runtime, device, {&default_add_context});
+    } else {
+      check(default_add_error.errorcode == lci::errorcode_t::fatal,
+            "default add scope accepted an HCA-only backend");
+    }
+
+    completion_context_t default_fetch_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t default_fetch_error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 0,
+                                  counter_offset, peer_rmr)
+            .runtime(runtime)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&default_fetch_context)();
+    if (atomic_scope == lci::net_atomic_scope_t::GLOBAL) {
+      check(default_fetch_error.is_posted(),
+            "default fetch-add scope was not accepted by a GLOBAL backend");
+      wait_for_completions(runtime, device, {&default_fetch_context});
+      check(fetch_result == 100,
+            "default fetch-add returned the wrong previous value");
+    } else {
+      check(default_fetch_error.errorcode == lci::errorcode_t::fatal,
+            "default fetch-add scope accepted an HCA-only backend");
+    }
+
+    lci::error_t no_scope_fetch_error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 0,
+                                  counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::NONE)
+            .device(device)
+            .endpoint(endpoint)();
+    lci::error_t no_scope_add_error =
+        lci::net_post_add_x(peer, 0, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::NONE)
+            .device(device)
+            .endpoint(endpoint)();
+    check(no_scope_fetch_error.errorcode == lci::errorcode_t::fatal,
+          "fetch-add accepted a NONE required atomic scope");
+    check(no_scope_add_error.errorcode == lci::errorcode_t::fatal,
+          "add accepted a NONE required atomic scope");
   }
   bootstrap_barrier();
 
@@ -389,6 +485,43 @@ int run_test(test_mode_t mode)
   if (rank == 1) {
     check(target.counter == 110,
           "non-fetch add did not update the remote value");
+  }
+  bootstrap_barrier();
+
+  if (rank == 0) {
+    completion_context_t discarded_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t discarded_error =
+        lci::net_post_add_x(peer, 4, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&discarded_context)();
+    check(discarded_error.is_posted(),
+          "discarded non-fetch add was not posted");
+    wait_for_discarded_completion(runtime, device);
+    check(endpoint.get_impl()->get_pending_ops() == 0,
+          "null-status poll did not retire the non-fetch add");
+    lci::wait_drained_x().runtime(runtime).device(device)();
+
+    completion_context_t recovered_context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t recovered_error =
+        lci::net_post_add_x(peer, 6, counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&recovered_context)();
+    check(recovered_error.is_posted(),
+          "non-fetch add did not reuse retired tracker storage");
+    wait_for_completions(runtime, device, {&recovered_context});
+    check(endpoint.get_impl()->get_pending_ops() == 0,
+          "reused non-fetch add remained pending");
+  }
+  bootstrap_barrier();
+  if (rank == 1) {
+    check(target.counter == 120,
+          "null-status poll did not retire the non-fetch add");
   }
   bootstrap_barrier();
 

--- a/tests/unit/atomic/test_network_atomic.cpp
+++ b/tests/unit/atomic/test_network_atomic.cpp
@@ -12,6 +12,10 @@
 #include <cstring>
 #include <vector>
 
+#if defined(LCI_USE_HIP)
+#include <hip/hip_runtime.h>
+#endif  // LCI_USE_HIP
+
 namespace
 {
 constexpr int kSkipReturnCode = 77;
@@ -20,6 +24,7 @@ constexpr int kMaxPolls = 1000000;
 enum class test_mode_t {
   expect_unsupported,
   require_ibv,
+  require_ibv_gpu,
 };
 
 [[noreturn]] void fail(const char* message)
@@ -38,7 +43,6 @@ void check(bool condition, const char* message)
 void bootstrap_barrier() { LCT_pmi_barrier(); }
 
 struct alignas(uint64_t) remote_words_t {
-  uint64_t ordered_value;
   uint64_t counter;
 };
 
@@ -46,6 +50,102 @@ struct completion_context_t {
   lci::net_opcode_t opcode;
   bool seen = false;
 };
+
+void wait_for_completions(lci::runtime_t runtime, lci::device_t device,
+                          const std::vector<completion_context_t*>& expected);
+
+const char* atomic_scope_str(lci::net_atomic_scope_t scope)
+{
+  switch (scope) {
+    case lci::net_atomic_scope_t::NONE:
+      return "NONE";
+    case lci::net_atomic_scope_t::HCA:
+      return "HCA";
+    case lci::net_atomic_scope_t::GLOBAL:
+      return "GLOBAL";
+    default:
+      return "invalid";
+  }
+}
+
+#if defined(LCI_USE_HIP)
+#define HIP_CHECK(call)                                                   \
+  do {                                                                    \
+    hipError_t error = (call);                                            \
+    if (error != hipSuccess) {                                            \
+      std::fprintf(stderr, "HIP failure %s:%d: %s\n", __FILE__, __LINE__, \
+                   hipGetErrorString(error));                             \
+      std::abort();                                                       \
+    }                                                                     \
+  } while (0)
+
+void run_gpu_atomic_test(lci::runtime_t runtime, lci::net_context_t net_context,
+                         lci::device_t device, lci::endpoint_t endpoint,
+                         int peer, lci::net_atomic_scope_t required_scope)
+{
+  constexpr uint64_t kInitialValue = 700;
+  constexpr uint64_t kAddValue = 9;
+  const int rank = lci::get_rank_me();
+
+  uint64_t* target = nullptr;
+  uint64_t* result = nullptr;
+  HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&target), sizeof(*target)));
+  HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&result), sizeof(*result)));
+  HIP_CHECK(hipMemcpy(target, &kInitialValue, sizeof(kInitialValue),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemset(result, 0, sizeof(*result)));
+
+  lci::mr_t target_mr = lci::register_memory_x(target, sizeof(*target))
+                            .runtime(runtime)
+                            .device(device)();
+  lci::mr_t result_mr = lci::register_memory_x(result, sizeof(*result))
+                            .runtime(runtime)
+                            .device(device)();
+  check(net_context.get_attr_use_dmabuf(),
+        "HIP GPU atomic target/result registration did not use DMA-BUF");
+
+  lci::rmr_t local_rmr = lci::get_rmr(target_mr);
+  std::array<lci::rmr_t, 2> local_rmrs = {local_rmr, local_rmr};
+  std::array<lci::rmr_t, 2> remote_rmrs = {};
+  lci::bootstrap::alltoall(local_rmrs.data(), remote_rmrs.data(),
+                           sizeof(local_rmr));
+
+  bootstrap_barrier();
+  if (rank == 0) {
+    completion_context_t context{lci::net_opcode_t::FETCH_ADD};
+    lci::error_t error =
+        lci::net_post_fetch_add_x(peer, result, result_mr, kAddValue, 0,
+                                  remote_rmrs[peer])
+            .runtime(runtime)
+            .required_atomic_scope(required_scope)
+            .device(device)
+            .endpoint(endpoint)
+            .user_context(&context)();
+    check(error.is_posted(), "GPU fetch-add was not posted");
+    wait_for_completions(runtime, device, {&context});
+
+    uint64_t observed_result = 0;
+    HIP_CHECK(hipMemcpy(&observed_result, result, sizeof(observed_result),
+                        hipMemcpyDeviceToHost));
+    check(observed_result == kInitialValue,
+          "GPU fetch-add returned the wrong previous value");
+  }
+  bootstrap_barrier();
+  if (rank == 1) {
+    uint64_t observed_target = 0;
+    HIP_CHECK(hipMemcpy(&observed_target, target, sizeof(observed_target),
+                        hipMemcpyDeviceToHost));
+    check(observed_target == kInitialValue + kAddValue,
+          "GPU fetch-add did not update the remote GPU value");
+  }
+  bootstrap_barrier();
+
+  lci::deregister_memory_x(&result_mr).runtime(runtime)();
+  lci::deregister_memory_x(&target_mr).runtime(runtime)();
+  HIP_CHECK(hipFree(result));
+  HIP_CHECK(hipFree(target));
+}
+#endif  // LCI_USE_HIP
 
 void wait_for_completions(lci::runtime_t runtime, lci::device_t device,
                           const std::vector<completion_context_t*>& expected)
@@ -113,21 +213,24 @@ int run_test(test_mode_t mode)
   lci::endpoint_t endpoint =
       lci::alloc_endpoint_x().runtime(runtime).device(device)();
 
-  const bool supports_fetch_add =
-      net_context.get_attr_support_uint64_fetch_add();
+  const lci::net_atomic_scope_t atomic_scope =
+      net_context.get_attr_atomic_scope();
   if (mode == test_mode_t::expect_unsupported) {
-    check(!supports_fetch_add,
+    check(atomic_scope == lci::net_atomic_scope_t::NONE,
           "OFI unexpectedly advertised uint64 fetch-add support");
     uint64_t result = 0;
     lci::error_t fetch_error =
         lci::net_post_fetch_add_x(0, &result, lci::MR_HOST, 1, 0, lci::RMR_NULL)
             .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
             .device(device)
             .endpoint(endpoint)();
-    lci::error_t add_error = lci::net_post_add_x(0, 1, 0, lci::RMR_NULL)
-                                 .runtime(runtime)
-                                 .device(device)
-                                 .endpoint(endpoint)();
+    lci::error_t add_error =
+        lci::net_post_add_x(0, 1, 0, lci::RMR_NULL)
+            .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
+            .device(device)
+            .endpoint(endpoint)();
     check(fetch_error.errorcode == lci::errorcode_t::fatal,
           "unsupported fetch-add did not fail explicitly");
     check(add_error.errorcode == lci::errorcode_t::fatal,
@@ -137,15 +240,26 @@ int run_test(test_mode_t mode)
   }
 
   if (net_context.get_attr_backend() != lci::attr_backend_t::ibv ||
-      !supports_fetch_add) {
+      atomic_scope == lci::net_atomic_scope_t::NONE) {
     free_runtime_objects(runtime, &device, &endpoint);
     return kSkipReturnCode;
   }
+
+#if !defined(LCI_USE_HIP)
+  if (mode == test_mode_t::require_ibv_gpu) {
+    free_runtime_objects(runtime, &device, &endpoint);
+    return kSkipReturnCode;
+  }
+#endif  // LCI_USE_HIP
 
   check(lci::get_rank_n() == 2,
         "the IBV network atomic test requires exactly two ranks");
   const int rank = lci::get_rank_me();
   const int peer = 1 - rank;
+  if (rank == 0) {
+    std::fprintf(stderr, "IBV uint64 atomic scope: %s\n",
+                 atomic_scope_str(atomic_scope));
+  }
 
   remote_words_t target = {};
   target.counter = 100;
@@ -177,29 +291,66 @@ int run_test(test_mode_t mode)
                            sizeof(local_rmr));
   const lci::rmr_t peer_rmr = remote_rmrs[peer];
   constexpr uint64_t counter_offset = offsetof(remote_words_t, counter);
-  constexpr uint64_t ordered_value_offset =
-      offsetof(remote_words_t, ordered_value);
 
   bootstrap_barrier();
   if (rank == 0) {
     uint64_t* misaligned_result =
         reinterpret_cast<uint64_t*>(misaligned_result_storage.data() + 1);
+    lci::error_t empty_rmr_fetch_error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
+                                  counter_offset, lci::RMR_NULL)
+            .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
+            .device(device)
+            .endpoint(endpoint)();
+    lci::error_t empty_rmr_add_error =
+        lci::net_post_add_x(peer, 1, counter_offset, lci::RMR_NULL)
+            .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
+            .device(device)
+            .endpoint(endpoint)();
     lci::error_t misaligned_result_error =
         lci::net_post_fetch_add_x(peer, misaligned_result, misaligned_result_mr,
                                   1, counter_offset, peer_rmr)
             .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
             .device(device)
             .endpoint(endpoint)();
     lci::error_t misaligned_remote_error =
         lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
                                   counter_offset + 1, peer_rmr)
             .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
             .device(device)
             .endpoint(endpoint)();
+    lci::error_t no_scope_error =
+        lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
+                                  counter_offset, peer_rmr)
+            .runtime(runtime)
+            .required_atomic_scope(lci::net_atomic_scope_t::NONE)
+            .device(device)
+            .endpoint(endpoint)();
+    check(empty_rmr_fetch_error.errorcode == lci::errorcode_t::fatal,
+          "empty RMR fetch-add was accepted");
+    check(empty_rmr_add_error.errorcode == lci::errorcode_t::fatal,
+          "empty RMR add was accepted");
     check(misaligned_result_error.errorcode == lci::errorcode_t::fatal,
           "misaligned fetch-add result was accepted");
     check(misaligned_remote_error.errorcode == lci::errorcode_t::fatal,
           "misaligned fetch-add remote address was accepted");
+    check(no_scope_error.errorcode == lci::errorcode_t::fatal,
+          "fetch-add accepted a NONE required atomic scope");
+    if (atomic_scope == lci::net_atomic_scope_t::HCA) {
+      lci::error_t global_scope_error =
+          lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 1,
+                                    counter_offset, peer_rmr)
+              .runtime(runtime)
+              .required_atomic_scope(lci::net_atomic_scope_t::GLOBAL)
+              .device(device)
+              .endpoint(endpoint)();
+      check(global_scope_error.errorcode == lci::errorcode_t::fatal,
+            "HCA atomic capability was accepted as GLOBAL");
+    }
   }
   bootstrap_barrier();
 
@@ -209,6 +360,7 @@ int run_test(test_mode_t mode)
         lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 7,
                                   counter_offset, peer_rmr)
             .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
             .device(device)
             .endpoint(endpoint)
             .user_context(&fetch_context)();
@@ -226,6 +378,7 @@ int run_test(test_mode_t mode)
     completion_context_t add_context{lci::net_opcode_t::FETCH_ADD};
     lci::error_t error = lci::net_post_add_x(peer, 3, counter_offset, peer_rmr)
                              .runtime(runtime)
+                             .required_atomic_scope(atomic_scope)
                              .device(device)
                              .endpoint(endpoint)
                              .user_context(&add_context)();
@@ -244,7 +397,7 @@ int run_test(test_mode_t mode)
     completion_context_t ordered_fetch_context{lci::net_opcode_t::FETCH_ADD};
     lci::error_t put_error =
         lci::net_post_put_x(peer, &ordered_value, sizeof(ordered_value),
-                            ordered_value_mr, ordered_value_offset, peer_rmr)
+                            ordered_value_mr, counter_offset, peer_rmr)
             .runtime(runtime)
             .device(device)
             .endpoint(endpoint)
@@ -253,6 +406,7 @@ int run_test(test_mode_t mode)
         lci::net_post_fetch_add_x(peer, &fetch_result, result_mr, 5,
                                   counter_offset, peer_rmr)
             .runtime(runtime)
+            .required_atomic_scope(atomic_scope)
             .device(device)
             .endpoint(endpoint)
             .user_context(&ordered_fetch_context)();
@@ -260,14 +414,12 @@ int run_test(test_mode_t mode)
     check(fetch_error.is_posted(), "ordering fetch-add was not posted");
     wait_for_completions(runtime, device,
                          {&write_context, &ordered_fetch_context});
-    check(fetch_result == 110,
+    check(fetch_result == ordered_value,
           "ordering fetch-add returned the wrong previous value");
   }
   bootstrap_barrier();
   if (rank == 1) {
-    check(target.ordered_value == ordered_value,
-          "same-QP write did not precede fetch-add at the remote rank");
-    check(target.counter == 115,
+    check(target.counter == ordered_value + 5,
           "ordering fetch-add did not update the remote value");
   }
   bootstrap_barrier();
@@ -283,13 +435,13 @@ int run_test(test_mode_t mode)
     std::vector<completion_context_t*> first_batch;
     for (size_t i = 0; i < 4; ++i) {
       lci::error_t error = endpoint.get_impl()->post_add(
-          peer, 1, counter_offset, peer_rmr, &add_contexts[i],
+          peer, 1, counter_offset, peer_rmr, atomic_scope, &add_contexts[i],
           false /* allow_retry */);
       check(error.is_posted(), "batched non-fetch add was not posted");
       first_batch.push_back(&add_contexts[i]);
     }
     lci::error_t backlog_error = endpoint.get_impl()->post_add(
-        peer, 1, counter_offset, peer_rmr, &add_contexts.back(),
+        peer, 1, counter_offset, peer_rmr, atomic_scope, &add_contexts.back(),
         false /* allow_retry */);
     check(backlog_error.errorcode == lci::errorcode_t::posted_backlog,
           "non-fetch add did not enter the backlog when the QP was full");
@@ -308,10 +460,17 @@ int run_test(test_mode_t mode)
   }
   bootstrap_barrier();
   if (rank == 1) {
-    check(target.counter == 120,
+    check(target.counter == ordered_value + 10,
           "batched or backlogged non-fetch adds lost an update");
   }
   bootstrap_barrier();
+
+#if defined(LCI_USE_HIP)
+  if (mode == test_mode_t::require_ibv_gpu) {
+    run_gpu_atomic_test(runtime, net_context, device, endpoint, peer,
+                        atomic_scope);
+  }
+#endif  // LCI_USE_HIP
 
   lci::deregister_memory_x(&misaligned_result_mr).runtime(runtime)();
   lci::deregister_memory_x(&ordered_value_mr).runtime(runtime)();
@@ -325,7 +484,9 @@ int run_test(test_mode_t mode)
 int main(int argc, char** argv)
 {
   if (argc != 2) {
-    std::fprintf(stderr, "Usage: %s --expect-unsupported|--require-ibv\n",
+    std::fprintf(stderr,
+                 "Usage: %s --expect-unsupported|--require-ibv|"
+                 "--require-ibv-gpu\n",
                  argv[0]);
     return 2;
   }
@@ -334,6 +495,9 @@ int main(int argc, char** argv)
   }
   if (std::strcmp(argv[1], "--require-ibv") == 0) {
     return run_test(test_mode_t::require_ibv);
+  }
+  if (std::strcmp(argv[1], "--require-ibv-gpu") == 0) {
+    return run_test(test_mode_t::require_ibv_gpu);
   }
   std::fprintf(stderr, "Unknown mode '%s'\n", argv[1]);
   return 2;

--- a/tests/unit/loopback/test_network.hpp
+++ b/tests/unit/loopback/test_network.hpp
@@ -152,7 +152,7 @@ TEST(NETWORK, completion_batch_unknown_rank_is_generic)
   lci::g_runtime_fina();
 }
 
-TEST(NETWORK, raw_atomic_failure_does_not_cast_user_context)
+TEST(NETWORK, raw_atomic_failure_uses_null_context)
 {
   lci::g_runtime_init();
   lci::runtime_t runtime = lci::g_default_runtime;
@@ -162,8 +162,7 @@ TEST(NETWORK, raw_atomic_failure_does_not_cast_user_context)
   lci::net_status_t status = {};
   status.opcode = lci::net_opcode_t::ERROR;
   status.rank = 7;
-  status.user_context = reinterpret_cast<void*>(static_cast<uintptr_t>(1));
-  status.failed_opcode = lci::net_opcode_t::FETCH_ADD;
+  status.user_context = nullptr;
 
   try {
     lci::process_completion_batch(runtime, device, endpoint, &status, 1);
@@ -173,32 +172,78 @@ TEST(NETWORK, raw_atomic_failure_does_not_cast_user_context)
   }
   EXPECT_TRUE(device.get_impl()->has_network_failed());
 
-  // The raw atomic context is deliberately not an internal_context_t. Failed
-  // teardown must remain abortive rather than dereferencing it or waiting for
-  // a completion that will never arrive.
+  // Raw atomic errors intentionally do not expose their user context through
+  // the generic error completion path.
   lci::g_runtime_fina();
 }
 
 #ifdef LCI_BACKEND_ENABLE_IBV
-TEST(NETWORK, ibv_atomic_tracker_abort_reclaims_discard_state)
+TEST(NETWORK, ibv_atomic_tracker_records_are_bounded_and_validated)
 {
   lci::ibv_atomic_tracker_t tracker;
-  tracker.free_discard_slots.push_back(7);
-  tracker.posted_ops.push_back(
-      {true, 3, reinterpret_cast<void*>(static_cast<uintptr_t>(1))});
-  tracker.posted_ops.push_back(
-      {false, 0, reinterpret_cast<void*>(static_cast<uintptr_t>(2))});
+  tracker.initialize(2, 7);
+  auto* records = tracker.records.data();
+  uintptr_t complete_wr_id = 0;
+  size_t discard_slot = 0;
+  void* complete_context = reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+  ASSERT_TRUE(
+      tracker.prepare(true, complete_context, &discard_slot, &complete_wr_id)
+          .is_done());
+  EXPECT_EQ(tracker.records.data(), records);
+  EXPECT_EQ(discard_slot, 8u);
+  EXPECT_FALSE(tracker.complete(complete_wr_id + 1, nullptr));
 
+  void* completed_context = nullptr;
+  EXPECT_TRUE(tracker.complete(complete_wr_id, &completed_context));
+  EXPECT_EQ(completed_context, complete_context);
+  EXPECT_TRUE(tracker.empty());
+
+  uintptr_t cancel_wr_id = 0;
+  ASSERT_TRUE(
+      tracker.prepare(true, nullptr, &discard_slot, &cancel_wr_id).is_done());
+  EXPECT_TRUE(tracker.cancel(cancel_wr_id));
+  EXPECT_TRUE(tracker.empty());
+  EXPECT_NE(std::find(tracker.free_discard_slots.begin(),
+                      tracker.free_discard_slots.end(), discard_slot),
+            tracker.free_discard_slots.end());
+
+  uintptr_t first_wr_id = 0;
+  uintptr_t second_wr_id = 0;
+  size_t abort_discard_slot = 0;
+  ASSERT_TRUE(tracker.prepare(true, nullptr, &abort_discard_slot, &first_wr_id)
+                  .is_done());
+  ASSERT_TRUE(
+      tracker.prepare(false, nullptr, nullptr, &second_wr_id).is_done());
+  EXPECT_EQ(tracker.prepare(false, nullptr, nullptr, &complete_wr_id).errorcode,
+            lci::errorcode_t::retry_nomem);
   EXPECT_EQ(tracker.abort(), 2u);
-  EXPECT_TRUE(tracker.posted_ops.empty());
+  EXPECT_TRUE(tracker.empty());
   EXPECT_NE(std::find(tracker.free_discard_slots.begin(),
-                      tracker.free_discard_slots.end(), 3),
+                      tracker.free_discard_slots.end(), abort_discard_slot),
             tracker.free_discard_slots.end());
-  EXPECT_NE(std::find(tracker.free_discard_slots.begin(),
-                      tracker.free_discard_slots.end(), 7),
-            tracker.free_discard_slots.end());
+  EXPECT_FALSE(tracker.complete(first_wr_id, nullptr));
 }
 #endif  // LCI_BACKEND_ENABLE_IBV
+
+TEST(NETWORK, uint64_atomic_scope_matrix)
+{
+  using scope_t = lci::net_atomic_scope_t;
+  EXPECT_FALSE(lci::is_valid_uint64_atomic_scope(scope_t::NONE, scope_t::NONE));
+  EXPECT_FALSE(lci::is_valid_uint64_atomic_scope(scope_t::NONE, scope_t::HCA));
+  EXPECT_FALSE(
+      lci::is_valid_uint64_atomic_scope(scope_t::NONE, scope_t::GLOBAL));
+
+  EXPECT_FALSE(lci::is_valid_uint64_atomic_scope(scope_t::HCA, scope_t::NONE));
+  EXPECT_TRUE(lci::is_valid_uint64_atomic_scope(scope_t::HCA, scope_t::HCA));
+  EXPECT_FALSE(
+      lci::is_valid_uint64_atomic_scope(scope_t::HCA, scope_t::GLOBAL));
+
+  EXPECT_FALSE(
+      lci::is_valid_uint64_atomic_scope(scope_t::GLOBAL, scope_t::NONE));
+  EXPECT_TRUE(lci::is_valid_uint64_atomic_scope(scope_t::GLOBAL, scope_t::HCA));
+  EXPECT_TRUE(
+      lci::is_valid_uint64_atomic_scope(scope_t::GLOBAL, scope_t::GLOBAL));
+}
 
 TEST(NETWORK, completion_failure_uses_abortive_teardown)
 {

--- a/tests/unit/loopback/test_network.hpp
+++ b/tests/unit/loopback/test_network.hpp
@@ -152,6 +152,54 @@ TEST(NETWORK, completion_batch_unknown_rank_is_generic)
   lci::g_runtime_fina();
 }
 
+TEST(NETWORK, raw_atomic_failure_does_not_cast_user_context)
+{
+  lci::g_runtime_init();
+  lci::runtime_t runtime = lci::g_default_runtime;
+  lci::device_t device = lci::get_default_device();
+  lci::endpoint_t endpoint = lci::get_default_endpoint();
+
+  lci::net_status_t status = {};
+  status.opcode = lci::net_opcode_t::ERROR;
+  status.rank = 7;
+  status.user_context = reinterpret_cast<void*>(static_cast<uintptr_t>(1));
+  status.failed_opcode = lci::net_opcode_t::FETCH_ADD;
+
+  try {
+    lci::process_completion_batch(runtime, device, endpoint, &status, 1);
+    FAIL() << "Expected peer_failure_error";
+  } catch (const lci::peer_failure_error& error) {
+    EXPECT_EQ(error.failed_rank(), 7);
+  }
+  EXPECT_TRUE(device.get_impl()->has_network_failed());
+
+  // The raw atomic context is deliberately not an internal_context_t. Failed
+  // teardown must remain abortive rather than dereferencing it or waiting for
+  // a completion that will never arrive.
+  lci::g_runtime_fina();
+}
+
+#ifdef LCI_BACKEND_ENABLE_IBV
+TEST(NETWORK, ibv_atomic_tracker_abort_reclaims_discard_state)
+{
+  lci::ibv_atomic_tracker_t tracker;
+  tracker.free_discard_slots.push_back(7);
+  tracker.posted_ops.push_back(
+      {true, 3, reinterpret_cast<void*>(static_cast<uintptr_t>(1))});
+  tracker.posted_ops.push_back(
+      {false, 0, reinterpret_cast<void*>(static_cast<uintptr_t>(2))});
+
+  EXPECT_EQ(tracker.abort(), 2u);
+  EXPECT_TRUE(tracker.posted_ops.empty());
+  EXPECT_NE(std::find(tracker.free_discard_slots.begin(),
+                      tracker.free_discard_slots.end(), 3),
+            tracker.free_discard_slots.end());
+  EXPECT_NE(std::find(tracker.free_discard_slots.begin(),
+                      tracker.free_discard_slots.end(), 7),
+            tracker.free_discard_slots.end());
+}
+#endif  // LCI_BACKEND_ENABLE_IBV
+
 TEST(NETWORK, completion_failure_uses_abortive_teardown)
 {
   lci::g_runtime_init();

--- a/tests/unit/loopback/test_network.hpp
+++ b/tests/unit/loopback/test_network.hpp
@@ -3,6 +3,65 @@
 
 namespace test_network
 {
+class retry_atomic_backlog_endpoint_t : public lci::endpoint_impl_t
+{
+ public:
+  explicit retry_atomic_backlog_endpoint_t(lci::device_t device)
+      : lci::endpoint_impl_t(device, lci::endpoint_t::attr_t{})
+  {
+  }
+
+ private:
+  static lci::error_t retry() { return lci::errorcode_t::retry_nomem; }
+
+  lci::error_t post_sends_impl(int, void*, size_t, lci::net_imm_data_t, void*,
+                               bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_send_impl(int, void*, size_t, lci::mr_t,
+                              lci::net_imm_data_t, void*, bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_puts_impl(int, void*, size_t, uint64_t, lci::rmr_t, void*,
+                              bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_put_impl(int, void*, size_t, lci::mr_t, uint64_t,
+                             lci::rmr_t, void*, bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_putImms_impl(int, void*, size_t, uint64_t, lci::rmr_t,
+                                 lci::net_imm_data_t, void*, bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_putImm_impl(int, void*, size_t, lci::mr_t, uint64_t,
+                                lci::rmr_t, lci::net_imm_data_t, void*,
+                                bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_get_impl(int, void*, size_t, lci::mr_t, uint64_t,
+                             lci::rmr_t, void*, bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_fetch_add_impl(int, uint64_t*, lci::mr_t, uint64_t,
+                                   uint64_t, lci::rmr_t, void*, bool) override
+  {
+    return retry();
+  }
+  lci::error_t post_add_impl(int, uint64_t, uint64_t, lci::rmr_t, void*,
+                             bool) override
+  {
+    return retry();
+  }
+};
+
 TEST(NETWORK, completion_batch_processes_successes_and_all_errors)
 {
   lci::g_runtime_init();
@@ -152,17 +211,22 @@ TEST(NETWORK, completion_batch_unknown_rank_is_generic)
   lci::g_runtime_fina();
 }
 
-TEST(NETWORK, raw_atomic_failure_uses_null_context)
+TEST(NETWORK, atomic_failure_preserves_raw_context)
 {
   lci::g_runtime_init();
   lci::runtime_t runtime = lci::g_default_runtime;
   lci::device_t device = lci::get_default_device();
   lci::endpoint_t endpoint = lci::get_default_endpoint();
 
+  // A raw atomic context is not owned by high-level LCI progress. Deliberately
+  // give it a conflicting rank so an accidental internal_context_t cast would
+  // turn this into a generic failure instead of the backend-reported peer.
+  auto* raw_context = new lci::internal_context_t;
+  raw_context->rank = 42;
   lci::net_status_t status = {};
-  status.opcode = lci::net_opcode_t::ERROR;
+  status.opcode = lci::net_opcode_t::FETCH_ADD_ERROR;
   status.rank = 7;
-  status.user_context = nullptr;
+  status.user_context = raw_context;
 
   try {
     lci::process_completion_batch(runtime, device, endpoint, &status, 1);
@@ -171,9 +235,33 @@ TEST(NETWORK, raw_atomic_failure_uses_null_context)
     EXPECT_EQ(error.failed_rank(), 7);
   }
   EXPECT_TRUE(device.get_impl()->has_network_failed());
+  EXPECT_EQ(status.user_context, raw_context);
+  delete raw_context;
+  lci::g_runtime_fina();
+}
 
-  // Raw atomic errors intentionally do not expose their user context through
-  // the generic error completion path.
+TEST(NETWORK, queued_atomic_backlog_is_aborted_during_failed_device_teardown)
+{
+  lci::g_runtime_init();
+  lci::device_t device = lci::get_default_device();
+  auto* endpoint = new retry_atomic_backlog_endpoint_t(device);
+  endpoint->net_context_attr.atomic_scope = lci::net_atomic_scope_t::HCA;
+
+  lci::rmr_t rmr;
+  rmr.base = 8;
+  int raw_context = 0;
+  lci::error_t error =
+      endpoint->post_add(0, 1, 0, rmr, lci::net_atomic_scope_t::HCA,
+                         &raw_context, false /* allow_retry */);
+  EXPECT_EQ(error.errorcode, lci::errorcode_t::posted_backlog);
+  EXPECT_FALSE(endpoint->is_backlog_queue_empty());
+  EXPECT_FALSE(endpoint->is_backlog_queue_empty(0));
+
+  device.get_impl()->mark_network_failed();
+  // The base endpoint destructor aborts its locked backlog before the queue
+  // destructor asserts that no entries remain.
+  delete endpoint;
+
   lci::g_runtime_fina();
 }
 


### PR DESCRIPTION
## Summary

- add capability-scoped uint64 network fetch-add and non-fetch add APIs
- implement native IBV atomics with bounded completion tracking and registered discard storage
- preserve same-QP write-before-atomic ordering and existing opcode ABI
- report unsupported atomics explicitly for OFI and other providers
- validate registered result storage and the effective remote atomic address
- add focused host, HIP DMA-BUF, ordering, backlog, and unsupported-provider tests

The endpoint wrapper owns provider-independent capability, address, ordering, retry, and pending-operation handling. Provider implementations only post and retire the backend operation. Generic network failure and backlog-teardown behavior is intentionally left unchanged by this PR.

## Validation

- warnings-as-errors CPU/IBV build passed
- warnings-as-errors HIP/IBV build passed
- warnings-as-errors OFI build passed
- OFI loopback and unsupported-atomic tests passed
- IBV hardware tests skip locally when no active IBV device is available
- earlier `banff19-29` validation covered host atomic, HIP DMA-BUF atomic, loopback, and a representative 3-rank collective

Fixes #191

Parent integration: AMD-RAD/glci#53
